### PR TITLE
[feat/item] 티켓 & 굿즈 상세 조회 구현

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.item.dto.request.CreateItemRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.CreateItemResponseDto;
+import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemResponseDto;
 import com.sparta.spartatigers.domain.item.service.ItemService;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
@@ -45,6 +47,14 @@ public class ItemController {
             @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
 
         Page<ReadItemResponseDto> response = itemService.findAllItems(userPrincipal, pageable);
+
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/{itemId}")
+    public ApiResponse<ReadItemDetailResponseDto> findItemById(@PathVariable Long itemId) {
+
+        ReadItemDetailResponseDto response = itemService.findItemById(itemId);
 
         return ApiResponse.ok(response);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemDetailResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemDetailResponseDto.java
@@ -1,0 +1,34 @@
+package com.sparta.spartatigers.domain.item.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.sparta.spartatigers.domain.item.model.entity.Item;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Category;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
+import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
+
+public record ReadItemDetailResponseDto(
+        Long id,
+        UserResponseDto user,
+        Category category,
+        String image,
+        String seatInfo,
+        String title,
+        String description,
+        Status status,
+        LocalDateTime createdAt) {
+
+    public static ReadItemDetailResponseDto from(Item item) {
+
+        return new ReadItemDetailResponseDto(
+                item.getId(),
+                UserResponseDto.from(item.getUser()),
+                item.getCategory(),
+                item.getImage(),
+                item.getSeatInfo(),
+                item.getTitle(),
+                item.getDescription(),
+                item.getStatus(),
+                item.getCreatedAt());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepositoryQuery.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepositoryQuery.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.item.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,4 +11,6 @@ import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
 public interface ItemRepositoryQuery {
 
     Page<Item> findAllByStatus(Status status, Pageable pageable);
+
+    Optional<Item> findItemById(Long itemId, Status status);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepositoryQueryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepositoryQueryImpl.java
@@ -1,6 +1,7 @@
 package com.sparta.spartatigers.domain.item.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -43,6 +44,18 @@ public class ItemRepositoryQueryImpl implements ItemRepositoryQuery {
         long count = (total == null) ? 0L : total;
 
         return new PageImpl<>(itemList, pageable, count);
+    }
+
+    @Override
+    public Optional<Item> findItemById(Long itemId, Status status) {
+
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(item)
+                        .where(itemStatusEq(status), item.id.eq(itemId))
+                        .join(item.user, user)
+                        .fetchJoin()
+                        .fetchOne());
     }
 
     private BooleanExpression itemStatusEq(Status status) {

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -9,12 +9,15 @@ import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.item.dto.request.CreateItemRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.CreateItemResponseDto;
+import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemResponseDto;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
 import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
 import com.sparta.spartatigers.domain.item.repository.ItemRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +47,15 @@ public class ItemService {
         Page<Item> itemList = itemRepository.findAllByStatus(Status.REGISTERED, pageable);
 
         return itemList.map(ReadItemResponseDto::from);
+    }
+
+    public ReadItemDetailResponseDto findItemById(Long itemId) {
+
+        Item item =
+                itemRepository
+                        .findItemById(itemId, Status.REGISTERED)
+                        .orElseThrow(() -> new ServerException(ExceptionCode.ITEM_NOT_FOUND));
+
+        return ReadItemDetailResponseDto.from(item);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -33,6 +33,7 @@ public enum ExceptionCode {
     EXCHANGE_REQUEST_NOT_FOUND("교환 요청을 찾을 수 없습니동"),
 
     // 아이템
+    ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
 
     // 직관 기록
 


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 교환 완료된 아이템을 조회할 경우 예외처리
- 존재하지 않은 아이템을 조회할 경우 예외처리

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- #27 

## 💬 기타 코멘트
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 단일 아이템의 상세 정보를 조회할 수 있는 새로운 API 엔드포인트(`/api/items/{itemId}`)가 추가되었습니다.

- **버그 수정**
  - 아이템이 존재하지 않을 경우 "아이템을 찾을 수 없습니다."라는 오류 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->