### PR TITLE
[feat/watchlist] 직관 기록 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/match/dto/MatchScheduleDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/match/dto/MatchScheduleDto.java
@@ -1,0 +1,38 @@
+package com.sparta.spartatigers.domain.match.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.match.model.entity.Match;
+import com.sparta.spartatigers.domain.team.model.entity.Stadium;
+import com.sparta.spartatigers.domain.team.model.entity.Team;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchScheduleDto {
+
+    private Long matchId;
+    private LocalDateTime matchTime;
+    private Team awayTeam;
+    private Integer awayScore;
+    private Team homeTeam;
+    private Integer homeScore;
+    private Stadium stadium;
+    private String remark; // 비고
+
+    public static MatchScheduleDto of(Match match) {
+        return new MatchScheduleDto(
+                match.getId(),
+                match.getMatchTime(),
+                match.getAwayTeam(),
+                match.getAwayScore(),
+                match.getHomeTeam(),
+                match.getHomeScore(),
+                match.getStadium(),
+                match.getRemark());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/match/model/entity/Match.java
+++ b/src/main/java/com/sparta/spartatigers/domain/match/model/entity/Match.java
@@ -1,6 +1,8 @@
 package com.sparta.spartatigers.domain.match.model.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import com.sparta.spartatigers.domain.common.entity.BaseEntity;
+import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.team.model.entity.Stadium;
 import com.sparta.spartatigers.domain.team.model.entity.Team;
 
@@ -44,9 +47,46 @@ public class Match extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private MatchResult matchResult;
 
-    @Column private int homeScore;
+    @Column private Integer homeScore;
 
-    @Column private int awayScore;
+    @Column private Integer awayScore;
+
+    @Column private String remark; // 비고
+
+    public static Match from(MatchScheduleDto matchSchedule) {
+        return new Match(
+                matchSchedule.getMatchTime(),
+                matchSchedule.getHomeTeam(),
+                matchSchedule.getAwayTeam(),
+                matchSchedule.getStadium(),
+                getResult(matchSchedule),
+                matchSchedule.getHomeScore(),
+                matchSchedule.getAwayScore(),
+                matchSchedule.getRemark());
+    }
+
+    public static List<Match> fromList(List<MatchScheduleDto> dtos) {
+        return dtos.stream().map(Match::from).collect(Collectors.toList());
+    }
+
+    private static MatchResult getResult(MatchScheduleDto matchSchedule) {
+        if (matchSchedule == null
+                || matchSchedule.getHomeScore() == null
+                || matchSchedule.getAwayScore() == null) {
+            return MatchResult.CANCEL;
+        }
+
+        Integer home = matchSchedule.getHomeScore();
+        Integer away = matchSchedule.getAwayScore();
+
+        if (home > away) {
+            return MatchResult.HOME_WIN;
+        } else if (home < away) {
+            return MatchResult.AWAY_WIN;
+        } else {
+            return MatchResult.DRAW;
+        }
+    }
 
     public enum MatchResult {
         HOME_WIN,

--- a/src/main/java/com/sparta/spartatigers/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/match/repository/MatchRepository.java
@@ -1,16 +1,18 @@
 package com.sparta.spartatigers.domain.match.repository;
 
-import com.sparta.spartatigers.domain.match.model.entity.Match;
 import java.time.LocalDateTime;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import com.sparta.spartatigers.domain.match.model.entity.Match;
+
 public interface MatchRepository extends JpaRepository<Match, Long> {
 
-	// 날짜별 조회
-	@Query(
-		"""
+    // 날짜별 조회
+    @Query(
+            """
 			SELECT m
 			FROM matches m
 			JOIN FETCH m.homeTeam
@@ -18,10 +20,10 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 			JOIN FETCH m.stadium
 			WHERE m.matchTime BETWEEN :start AND :end
 			""")
-	List<Match> findAllByMatchTimeBetween(LocalDateTime start, LocalDateTime end);
+    List<Match> findAllByMatchTimeBetween(LocalDateTime start, LocalDateTime end);
 
-	@Query(
-		"""
+    @Query(
+            """
 			SELECT m
 			FROM matches m
 			JOIN FETCH m.homeTeam
@@ -29,5 +31,5 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 			JOIN FETCH m.stadium
 			WHERE m.id = :id
 			""")
-	Match findByIdWithTeamsAndStadium(Long id);
+    Match findByIdWithTeamsAndStadium(Long id);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/match/repository/MatchRepository.java
@@ -1,14 +1,33 @@
 package com.sparta.spartatigers.domain.match.repository;
 
+import com.sparta.spartatigers.domain.match.model.entity.Match;
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.sparta.spartatigers.domain.match.model.entity.Match;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
 
-    // 날짜별 조회
-    List<Match> findAllByMatchTimeBetween(LocalDateTime start, LocalDateTime end);
+	// 날짜별 조회
+	@Query(
+		"""
+			SELECT m
+			FROM matches m
+			JOIN FETCH m.homeTeam
+			JOIN FETCH m.awayTeam
+			JOIN FETCH m.stadium
+			WHERE m.matchTime BETWEEN :start AND :end
+			""")
+	List<Match> findAllByMatchTimeBetween(LocalDateTime start, LocalDateTime end);
+
+	@Query(
+		"""
+			SELECT m
+			FROM matches m
+			JOIN FETCH m.homeTeam
+			JOIN FETCH m.awayTeam
+			JOIN FETCH m.stadium
+			WHERE m.id = :id
+			""")
+	Match findByIdWithTeamsAndStadium(Long id);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/model/CustomUserPrincipal.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/model/CustomUserPrincipal.java
@@ -53,7 +53,7 @@ public class CustomUserPrincipal implements UserDetails {
         return true;
     }
 
-	public Long getUserId(CustomUserPrincipal principal){
-		return principal.getUser().getId();
-	}
+    public Long getUserId(CustomUserPrincipal principal) {
+        return principal.getUser().getId();
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/model/CustomUserPrincipal.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/model/CustomUserPrincipal.java
@@ -53,7 +53,7 @@ public class CustomUserPrincipal implements UserDetails {
         return true;
     }
 
-    public Long getUserId(CustomUserPrincipal principal) {
+    public static Long getUserId(CustomUserPrincipal principal) {
         return principal.getUser().getId();
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/model/CustomUserPrincipal.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/model/CustomUserPrincipal.java
@@ -52,4 +52,8 @@ public class CustomUserPrincipal implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+	public Long getUserId(CustomUserPrincipal principal){
+		return principal.getUser().getId();
+	}
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/model/entity/User.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/model/entity/User.java
@@ -1,5 +1,6 @@
 package com.sparta.spartatigers.domain.user.model.entity;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import com.sparta.spartatigers.domain.common.entity.BaseEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class User extends BaseEntity {
+public class User extends BaseEntity implements Serializable {
 
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -1,11 +1,32 @@
 package com.sparta.spartatigers.domain.watchlist.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
+import com.sparta.spartatigers.domain.watchlist.service.WatchListService;
+import com.sparta.spartatigers.global.response.ApiResponse;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/watchlist")
-public class WatchListController {}
+public class WatchListController {
+
+    private final WatchListService watchListService;
+
+    /**
+     * 직관 기록 등록
+     *
+     * @return null
+     */
+    @PostMapping
+    public ApiResponse<CreateWatchListResponseDto> create(
+            @RequestBody CreateWatchListRequestDto request) {
+        return ApiResponse.created(watchListService.create(request));
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -1,9 +1,14 @@
 package com.sparta.spartatigers.domain.watchlist.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -11,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.service.WatchListService;
 import com.sparta.spartatigers.global.response.ApiResponse;
 
@@ -31,5 +37,22 @@ public class WatchListController {
             @RequestBody CreateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.created(watchListService.create(request, principal));
+    }
+
+    /**
+     * 직관 기록 전체 조회
+     *
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param principal 유저 정보
+     * @return {@link WatchListResponseDto}
+     */
+    @GetMapping
+    public ApiResponse<Page<WatchListResponseDto>> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ApiResponse.ok(watchListService.find(pageable));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,7 +41,7 @@ public class WatchListController {
     }
 
     /**
-     * 직관 기록 전체 조회
+     * 직관 기록 다건 조회
      *
      * @param page 페이지 번호
      * @param size 페이지 크기
@@ -48,11 +49,25 @@ public class WatchListController {
      * @return {@link WatchListResponseDto}
      */
     @GetMapping
-    public ApiResponse<Page<WatchListResponseDto>> getAll(
+    public ApiResponse<Page<WatchListResponseDto>> findAll(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         Pageable pageable = PageRequest.of(page, size);
-        return ApiResponse.ok(watchListService.find(pageable));
+        return ApiResponse.ok(watchListService.findAll(pageable, principal));
+    }
+
+    /**
+     * 직관 기록 단건 조회
+     *
+     * @param watchListId 직관 기록 식별자
+     * @param principal 유저 정보
+     * @return {@link WatchListResponseDto}
+     */
+    @GetMapping("/{watchListId}")
+    public ApiResponse<?> findOne(
+            @PathVariable Long watchListId,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ApiResponse.ok(watchListService.findOne(watchListId, principal));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.dto.request.SearchWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
@@ -103,5 +104,24 @@ public class WatchListController {
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         watchListService.delete(watchListId, principal);
         return ApiResponse.ok("삭제 완료");
+    }
+
+    /**
+     * 직관 기록 검색
+     *
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param request 요청 DTO {@link SearchWatchListRequestDto}
+     * @param principal 유저 정보
+     * @return {@link Page<WatchListResponseDto>}
+     */
+    @GetMapping("/search")
+    public ApiResponse<?> search(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestBody SearchWatchListRequestDto request,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ApiResponse.ok(watchListService.search(pageable, request, principal));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -1,5 +1,6 @@
 package com.sparta.spartatigers.domain.watchlist.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.service.WatchListService;
@@ -26,7 +28,8 @@ public class WatchListController {
      */
     @PostMapping
     public ApiResponse<CreateWatchListResponseDto> create(
-            @RequestBody CreateWatchListRequestDto request) {
-        return ApiResponse.created(watchListService.create(request));
+            @RequestBody CreateWatchListRequestDto request,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ApiResponse.created(watchListService.create(request, principal));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.service.WatchListService;
@@ -69,5 +71,21 @@ public class WatchListController {
             @PathVariable Long watchListId,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.ok(watchListService.findOne(watchListId, principal));
+    }
+
+    /**
+     * 직관 기록 수정
+     *
+     * @param watchListId 직관 기록 식별자
+     * @param request 요청 DTO {@link UpdateWatchListRequestDto}
+     * @param principal 유저 정보
+     * @return {@link WatchListResponseDto}
+     */
+    @PatchMapping("/{watchListId}")
+    public ApiResponse<?> update(
+            @PathVariable Long watchListId,
+            @RequestBody UpdateWatchListRequestDto request,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ApiResponse.ok(watchListService.update(watchListId, request, principal));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -115,7 +115,7 @@ public class WatchListController {
      * @param principal 유저 정보
      * @return {@link Page<WatchListResponseDto>}
      */
-    @GetMapping("/search")
+    @PostMapping("/search")
     public ApiResponse<?> search(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -87,5 +88,20 @@ public class WatchListController {
             @RequestBody UpdateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.ok(watchListService.update(watchListId, request, principal));
+    }
+
+    /**
+     * 직관 기록 삭제
+     *
+     * @param watchListId 직관 기록 식별자
+     * @param principal 유저 정보
+     * @return String
+     */
+    @DeleteMapping("/{watchListId}")
+    public ApiResponse<?> delete(
+            @PathVariable Long watchListId,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        watchListService.delete(watchListId, principal);
+        return ApiResponse.ok("삭제 완료");
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -22,7 +22,7 @@ public class WatchListController {
     /**
      * 직관 기록 등록
      *
-     * @return null
+     * @return {@link CreateWatchListResponseDto}
      */
     @PostMapping
     public ApiResponse<CreateWatchListResponseDto> create(

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/MatchDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/MatchDto.java
@@ -1,0 +1,13 @@
+package com.sparta.spartatigers.domain.watchlist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchDto {
+
+    private Long id;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/RecordDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/RecordDto.java
@@ -13,7 +13,7 @@ import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 public class RecordDto {
 
     private String content;
-    private int rate;
+    private Integer rate;
 
     public static RecordDto of(CreateWatchListRequestDto dto) {
         return new RecordDto(dto.getRecord().getContent(), dto.getRecord().getRate());

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/RecordDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/RecordDto.java
@@ -1,0 +1,25 @@
+package com.sparta.spartatigers.domain.watchlist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordDto {
+
+    private String content;
+    private int rate;
+
+    public static RecordDto of(CreateWatchListRequestDto dto) {
+        return new RecordDto(dto.getRecord().getContent(), dto.getRecord().getRate());
+    }
+
+    public static RecordDto of(WatchList watchList) {
+        return new RecordDto(watchList.getContents(), watchList.getRating());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/CreateWatchListRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/CreateWatchListRequestDto.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.sparta.spartatigers.domain.watchlist.dto.MatchDto;
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -11,21 +14,4 @@ public class CreateWatchListRequestDto {
 
     private MatchDto match;
     private RecordDto record;
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class MatchDto {
-
-        private Long id;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RecordDto {
-
-        private String content;
-        private int rate;
-    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/CreateWatchListRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/CreateWatchListRequestDto.java
@@ -1,0 +1,31 @@
+package com.sparta.spartatigers.domain.watchlist.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateWatchListRequestDto {
+
+    private MatchDto match;
+    private RecordDto record;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MatchDto {
+
+        private Long id;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecordDto {
+
+        private String content;
+        private int rate;
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/SearchWatchListRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/SearchWatchListRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.spartatigers.domain.watchlist.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchWatchListRequestDto {
+
+    private String teamName;
+    private String stadiumName;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/UpdateWatchListRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/UpdateWatchListRequestDto.java
@@ -1,0 +1,15 @@
+package com.sparta.spartatigers.domain.watchlist.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateWatchListRequestDto {
+
+    private RecordDto record;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -1,14 +1,13 @@
 package com.sparta.spartatigers.domain.watchlist.dto.response;
 
-import com.sparta.spartatigers.domain.match.model.entity.Match;
-import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
-import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
+import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
 @Getter
 @NoArgsConstructor
@@ -29,6 +30,10 @@ public class CreateWatchListResponseDto {
 
         public static RecordDto of(CreateWatchListRequestDto dto) {
             return new RecordDto(dto.getRecord().getContent(), dto.getRecord().getRate());
+        }
+
+        public static RecordDto of(WatchList watchList) {
+            return new RecordDto(watchList.getContents(), watchList.getRating());
         }
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -17,7 +17,7 @@ public class CreateWatchListResponseDto {
     private MatchScheduleDto match;
     private RecordDto record;
 
-    public static CreateWatchListResponseDto from(Match match, CreateWatchListRequestDto request) {
-        return new CreateWatchListResponseDto(MatchScheduleDto.of(match), RecordDto.of(request));
+    public static CreateWatchListResponseDto from(Match match, RecordDto recordDto) {
+        return new CreateWatchListResponseDto(MatchScheduleDto.of(match), recordDto);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -1,5 +1,8 @@
 package com.sparta.spartatigers.domain.watchlist.dto.response;
 
+import com.sparta.spartatigers.domain.match.model.entity.Match;
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +18,7 @@ public class CreateWatchListResponseDto {
     private MatchScheduleDto match;
     private RecordDto record;
 
-    public static CreateWatchListResponseDto from(MatchScheduleDto match, RecordDto record) {
-        return new CreateWatchListResponseDto(match, record);
+    public static CreateWatchListResponseDto from(Match match, CreateWatchListRequestDto request) {
+        return new CreateWatchListResponseDto(MatchScheduleDto.of(match), RecordDto.of(request));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -15,8 +15,8 @@ public class CreateWatchListResponseDto {
     private MatchScheduleDto match;
     private RecordDto record;
 
-    public static CreateWatchListResponseDto of() {
-        return new CreateWatchListResponseDto();
+    public static CreateWatchListResponseDto from(MatchScheduleDto match, RecordDto record) {
+        return new CreateWatchListResponseDto(match, record);
     }
 
     @Getter

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
-import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -5,8 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
-import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
-import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 
 @Getter
 @NoArgsConstructor
@@ -18,22 +17,5 @@ public class CreateWatchListResponseDto {
 
     public static CreateWatchListResponseDto from(MatchScheduleDto match, RecordDto record) {
         return new CreateWatchListResponseDto(match, record);
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RecordDto {
-
-        private String content;
-        private int rate;
-
-        public static RecordDto of(CreateWatchListRequestDto dto) {
-            return new RecordDto(dto.getRecord().getContent(), dto.getRecord().getRate());
-        }
-
-        public static RecordDto of(WatchList watchList) {
-            return new RecordDto(watchList.getContents(), watchList.getRating());
-        }
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/CreateWatchListResponseDto.java
@@ -1,0 +1,34 @@
+package com.sparta.spartatigers.domain.watchlist.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateWatchListResponseDto {
+
+    private MatchScheduleDto match;
+    private RecordDto record;
+
+    public static CreateWatchListResponseDto of() {
+        return new CreateWatchListResponseDto();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecordDto {
+
+        private String content;
+        private int rate;
+
+        public static RecordDto of(CreateWatchListRequestDto dto) {
+            return new RecordDto(dto.getRecord().getContent(), dto.getRecord().getRate());
+        }
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
@@ -12,12 +12,13 @@ import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WatchListResponseDto {
-    private RecordDto recordDto;
-    private MatchScheduleDto matchScheduleDto;
+    private Long id;
+    private RecordDto record;
+    private MatchScheduleDto matchSchedule;
 
     public static WatchListResponseDto of(WatchList watchList) {
         MatchScheduleDto matchScheduleDto = MatchScheduleDto.of(watchList.getMatch());
         RecordDto recordDto = RecordDto.of(watchList);
-        return new WatchListResponseDto(recordDto, matchScheduleDto);
+        return new WatchListResponseDto(watchList.getId(), recordDto, matchScheduleDto);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
-import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto.RecordDto;
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
 @Getter
@@ -14,11 +14,11 @@ import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 public class WatchListResponseDto {
     private Long id;
     private RecordDto record;
-    private MatchScheduleDto matchSchedule;
+    private MatchScheduleDto match;
 
     public static WatchListResponseDto of(WatchList watchList) {
         MatchScheduleDto matchScheduleDto = MatchScheduleDto.of(watchList.getMatch());
-        RecordDto recordDto = RecordDto.of(watchList);
-        return new WatchListResponseDto(watchList.getId(), recordDto, matchScheduleDto);
+        return new WatchListResponseDto(
+                watchList.getId(), RecordDto.of(watchList), matchScheduleDto);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
@@ -1,0 +1,23 @@
+package com.sparta.spartatigers.domain.watchlist.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto.RecordDto;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatchListResponseDto {
+    private RecordDto recordDto;
+    private MatchScheduleDto matchScheduleDto;
+
+    public static WatchListResponseDto of(WatchList watchList) {
+        MatchScheduleDto matchScheduleDto = MatchScheduleDto.of(watchList.getMatch());
+        RecordDto recordDto = RecordDto.of(watchList);
+        return new WatchListResponseDto(recordDto, matchScheduleDto);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/WatchListResponseDto.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.dto.response;
 
+import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,10 +17,16 @@ public class WatchListResponseDto {
     private Long id;
     private RecordDto record;
     private MatchScheduleDto match;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static WatchListResponseDto of(WatchList watchList) {
         MatchScheduleDto matchScheduleDto = MatchScheduleDto.of(watchList.getMatch());
         return new WatchListResponseDto(
-                watchList.getId(), RecordDto.of(watchList), matchScheduleDto);
+                watchList.getId(),
+                RecordDto.of(watchList),
+                matchScheduleDto,
+                watchList.getCreatedAt(),
+                watchList.getUpdatedAt());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
@@ -44,9 +44,9 @@ public class WatchList extends BaseEntity {
         this.match = match;
     }
 
-    public static WatchList from(Match match, CreateWatchListRequestDto dto) {
+    public static WatchList from(Match match, CreateWatchListRequestDto dto, User user) {
         return new WatchList(
-                dto.getRecord().getContent(), dto.getRecord().getRate(), null, null, match);
+                dto.getRecord().getContent(), dto.getRecord().getRate(), null, user, match);
     }
 
     public static WatchList of(WatchList watchList) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
@@ -37,12 +37,32 @@ public class WatchList extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Match match;
 
+    public WatchList(String contents, int rating, User user, Match match) {
+        this.contents = contents;
+        this.rating = rating;
+        this.user = user;
+        this.match = match;
+    }
+
     public static WatchList from(Match match, CreateWatchListRequestDto dto) {
         return new WatchList(
                 dto.getRecord().getContent(), dto.getRecord().getRate(), null, null, match);
     }
 
+    public static WatchList of(WatchList watchList) {
+        return new WatchList(
+                watchList.getContents(),
+                watchList.getRating(),
+                watchList.getUser(),
+                watchList.getMatch());
+    }
+
     public void deleted() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void update(String content, Integer rating) {
+        if (content != null) this.contents = content;
+        if (rating != null) this.rating = rating;
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
@@ -1,7 +1,5 @@
 package com.sparta.spartatigers.domain.watchlist.model.entity;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,7 +25,7 @@ public class WatchList extends BaseEntity {
 
     @Column private int rating;
 
-    @Column private LocalDateTime deletedAt;
+    //    @Column private LocalDateTime deletedAt;
 
     @JoinColumn(name = "user_id")
     @ManyToOne(fetch = FetchType.LAZY)
@@ -37,16 +35,8 @@ public class WatchList extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Match match;
 
-    public WatchList(String contents, int rating, User user, Match match) {
-        this.contents = contents;
-        this.rating = rating;
-        this.user = user;
-        this.match = match;
-    }
-
     public static WatchList from(Match match, CreateWatchListRequestDto dto, User user) {
-        return new WatchList(
-                dto.getRecord().getContent(), dto.getRecord().getRate(), null, user, match);
+        return new WatchList(dto.getRecord().getContent(), dto.getRecord().getRate(), user, match);
     }
 
     public static WatchList of(WatchList watchList) {
@@ -57,9 +47,9 @@ public class WatchList extends BaseEntity {
                 watchList.getMatch());
     }
 
-    public void deleted() {
-        this.deletedAt = LocalDateTime.now();
-    }
+    //    public void deleted() {
+    //        this.deletedAt = LocalDateTime.now();
+    //    }
 
     public void update(String content, Integer rating) {
         if (content != null) this.contents = content;

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.spartatigers.domain.common.entity.BaseEntity;
@@ -16,6 +17,7 @@ import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 
+@Getter
 @Entity(name = "watch_list")
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/model/entity/WatchList.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import com.sparta.spartatigers.domain.common.entity.BaseEntity;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 
 @Entity(name = "watch_list")
 @NoArgsConstructor
@@ -33,6 +34,11 @@ public class WatchList extends BaseEntity {
     @JoinColumn(name = "match_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Match match;
+
+    public static WatchList from(Match match, CreateWatchListRequestDto dto) {
+        return new WatchList(
+                dto.getRecord().getContent(), dto.getRecord().getRate(), null, null, match);
+    }
 
     public void deleted() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepository.java
@@ -26,4 +26,16 @@ public interface WatchListQueryRepository {
      * @return {@link Optional<WatchList>}
      */
     Optional<WatchList> findByIdWithMatchDetails(Long watchListId, Long userId);
+
+    /**
+     * 팀명, 구장명을 검색하여 작성한 직관 기록 목록을 페이지로 가져오는 메서드
+     *
+     * @param userId 유저 식별자
+     * @param teamName 팀명
+     * @param stadiumName 구장명
+     * @param pageable 페이지 정보
+     * @return {@link Page<WatchList>}
+     */
+    Page<WatchList> findAllByKeyword(
+            Long userId, String teamName, String stadiumName, Pageable pageable);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepository.java
@@ -1,0 +1,29 @@
+package com.sparta.spartatigers.domain.watchlist.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+
+public interface WatchListQueryRepository {
+
+    /**
+     * userId를 가진 사용자가 작성한 직관 기록 목록을 페이지로 가져오는 메서드
+     *
+     * @param userId 유저 식별자
+     * @param pageable 페이지 정보
+     * @return {@link Page<WatchList>}
+     */
+    Page<WatchList> findAllByUserIdWithMatchDetails(Long userId, Pageable pageable);
+
+    /**
+     * userId를 가진 사용자가 작성한 직관 기록 목록 중 watchListId의 직관 기록을 가져오는 메서드
+     *
+     * @param watchListId 직관 기록 식별자
+     * @param userId 유저 식별자
+     * @return {@link Optional<WatchList>}
+     */
+    Optional<WatchList> findByIdWithMatchDetails(Long watchListId, Long userId);
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
@@ -26,11 +26,11 @@ public class WatchListQueryRepositoryImpl implements WatchListQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    QWatchList watchList = QWatchList.watchList;
-    QMatch match = QMatch.match;
-    QTeam homeTeam = new QTeam("homeTeam");
-    QTeam awayTeam = new QTeam("awayTeam");
-    QStadium stadium = QStadium.stadium;
+    private static final QWatchList watchList = QWatchList.watchList;
+	private static final QMatch match = QMatch.match;
+	private static final QTeam homeTeam = new QTeam("homeTeam");
+	private static final QTeam awayTeam = new QTeam("awayTeam");
+	private static final QStadium stadium = QStadium.stadium;
 
     @Override
     public Page<WatchList> findAllByUserIdWithMatchDetails(Long userId, Pageable pageable) {
@@ -118,7 +118,7 @@ public class WatchListQueryRepositoryImpl implements WatchListQueryRepository {
                 .match
                 .awayTeam
                 .name
-                .eq(teamName)
+                .containsIgnoreCase(teamName)
                 .or(watchList.match.homeTeam.name.containsIgnoreCase(teamName));
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
@@ -27,10 +27,10 @@ public class WatchListQueryRepositoryImpl implements WatchListQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     private static final QWatchList watchList = QWatchList.watchList;
-	private static final QMatch match = QMatch.match;
-	private static final QTeam homeTeam = new QTeam("homeTeam");
-	private static final QTeam awayTeam = new QTeam("awayTeam");
-	private static final QStadium stadium = QStadium.stadium;
+    private static final QMatch match = QMatch.match;
+    private static final QTeam homeTeam = new QTeam("homeTeam");
+    private static final QTeam awayTeam = new QTeam("awayTeam");
+    private static final QStadium stadium = QStadium.stadium;
 
     @Override
     public Page<WatchList> findAllByUserIdWithMatchDetails(Long userId, Pageable pageable) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.sparta.spartatigers.domain.watchlist.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.domain.match.model.entity.QMatch;
+import com.sparta.spartatigers.domain.team.model.entity.QStadium;
+import com.sparta.spartatigers.domain.team.model.entity.QTeam;
+import com.sparta.spartatigers.domain.watchlist.model.entity.QWatchList;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Repository
+@RequiredArgsConstructor
+public class WatchListQueryRepositoryImpl implements WatchListQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QWatchList watchList = QWatchList.watchList;
+    QMatch match = QMatch.match;
+    QTeam homeTeam = new QTeam("homeTeam");
+    QTeam awayTeam = new QTeam("awayTeam");
+    QStadium stadium = QStadium.stadium;
+
+    @Override
+    public Page<WatchList> findAllByUserIdWithMatchDetails(Long userId, Pageable pageable) {
+        List<WatchList> results =
+                queryFactory
+                        .selectFrom(watchList)
+                        .join(watchList.match, match)
+                        .fetchJoin()
+                        .join(match.homeTeam, homeTeam)
+                        .fetchJoin()
+                        .join(match.awayTeam, awayTeam)
+                        .fetchJoin()
+                        .join(match.stadium, stadium)
+                        .fetchJoin()
+                        .where(isUserOwner(userId))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        Long total =
+                queryFactory
+                        .select(watchList.count())
+                        .from(watchList)
+                        .where(isUserOwner(userId))
+                        .fetchOne();
+
+        return new PageImpl<>(results, pageable, total != null ? total : 0);
+    }
+
+    @Override
+    public Optional<WatchList> findByIdWithMatchDetails(Long watchListId, Long userId) {
+        WatchList result =
+                queryFactory
+                        .selectFrom(watchList)
+                        .join(watchList.match, match)
+                        .fetchJoin()
+                        .join(match.homeTeam, homeTeam)
+                        .fetchJoin()
+                        .join(match.awayTeam, awayTeam)
+                        .fetchJoin()
+                        .join(match.stadium, stadium)
+                        .fetchJoin()
+                        .where(isUserOwner(userId), hasWatchListId(watchListId))
+                        .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    private BooleanExpression isUserOwner(Long userId) {
+        return watchList.user.id.eq(userId);
+    }
+
+    private BooleanExpression hasWatchListId(Long watchListId) {
+        return watchList.id.eq(watchListId);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListQueryRepositoryImpl.java
@@ -17,6 +17,7 @@ import com.sparta.spartatigers.domain.watchlist.model.entity.QWatchList;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
@@ -34,16 +35,7 @@ public class WatchListQueryRepositoryImpl implements WatchListQueryRepository {
     @Override
     public Page<WatchList> findAllByUserIdWithMatchDetails(Long userId, Pageable pageable) {
         List<WatchList> results =
-                queryFactory
-                        .selectFrom(watchList)
-                        .join(watchList.match, match)
-                        .fetchJoin()
-                        .join(match.homeTeam, homeTeam)
-                        .fetchJoin()
-                        .join(match.awayTeam, awayTeam)
-                        .fetchJoin()
-                        .join(match.stadium, stadium)
-                        .fetchJoin()
+                baseQueryWithMatchDetails()
                         .where(isUserOwner(userId))
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
@@ -62,20 +54,25 @@ public class WatchListQueryRepositoryImpl implements WatchListQueryRepository {
     @Override
     public Optional<WatchList> findByIdWithMatchDetails(Long watchListId, Long userId) {
         WatchList result =
-                queryFactory
-                        .selectFrom(watchList)
-                        .join(watchList.match, match)
-                        .fetchJoin()
-                        .join(match.homeTeam, homeTeam)
-                        .fetchJoin()
-                        .join(match.awayTeam, awayTeam)
-                        .fetchJoin()
-                        .join(match.stadium, stadium)
-                        .fetchJoin()
+                baseQueryWithMatchDetails()
                         .where(isUserOwner(userId), hasWatchListId(watchListId))
                         .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    /** 공통 조인 + fetchJoin 처리 메서드 */
+    private JPAQuery<WatchList> baseQueryWithMatchDetails() {
+        return queryFactory
+                .selectFrom(watchList)
+                .join(watchList.match, match)
+                .fetchJoin()
+                .join(match.homeTeam, homeTeam)
+                .fetchJoin()
+                .join(match.awayTeam, awayTeam)
+                .fetchJoin()
+                .join(match.stadium, stadium)
+                .fetchJoin();
     }
 
     private BooleanExpression isUserOwner(Long userId) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -11,6 +11,6 @@ public interface WatchListRepository
 
     default WatchList findDetailByIdAndOwnerOrThrow(Long watchListId, Long userId) {
         return findByIdWithMatchDetails(watchListId, userId)
-                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.WATCH_LIST_NOT_FOUN));
+                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.WATCH_LIST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
@@ -19,8 +20,10 @@ public interface WatchListRepository extends JpaRepository<WatchList, Long> {
 		JOIN FETCH w.match.awayTeam at
 		JOIN FETCH w.match.homeTeam ht
 		JOIN FETCH w.match.stadium s
+		WHERE w.user.id = :userId
 		""")
-    Page<WatchList> findAllWithMatchDetails(Pageable pageable);
+    Page<WatchList> findAllByUserIdWithMatchDetails(
+            @Param("userId") Long userId, Pageable pageable);
 
     @Query(
             """
@@ -30,7 +33,8 @@ public interface WatchListRepository extends JpaRepository<WatchList, Long> {
 		JOIN FETCH w.match.awayTeam at
 		JOIN FETCH w.match.homeTeam ht
 		JOIN FETCH w.match.stadium s
-		WHERE w.id = :id
+		WHERE w.id = :watchListId AND w.user.id = :userId
 		""")
-    Optional<WatchList> findByIdWithMatchDetails(Long id);
+    Optional<WatchList> findByIdWithMatchDetails(
+            @Param("watchListId") Long watchListId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -37,4 +37,10 @@ public interface WatchListRepository extends JpaRepository<WatchList, Long> {
 		""")
     Optional<WatchList> findByIdWithMatchDetails(
             @Param("watchListId") Long watchListId, @Param("userId") Long userId);
+
+    default WatchList findByIdOrElseThrow(
+            @Param("watchListId") Long watchListId, @Param("userId") Long userId) {
+        return findByIdWithMatchDetails(watchListId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -38,7 +38,7 @@ public interface WatchListRepository extends JpaRepository<WatchList, Long> {
     Optional<WatchList> findByIdWithMatchDetails(
             @Param("watchListId") Long watchListId, @Param("userId") Long userId);
 
-    default WatchList findByIdOrElseThrow(
+    default WatchList findDetailByIdAndOwnerOrThrow(
             @Param("watchListId") Long watchListId, @Param("userId") Long userId) {
         return findByIdWithMatchDetails(watchListId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,10 +1,10 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
-import com.sparta.spartatigers.global.exception.ExceptionCode;
-import com.sparta.spartatigers.global.exception.InvalidRequestException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
 
 public interface WatchListRepository
         extends JpaRepository<WatchList, Long>, WatchListQueryRepository {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,7 +1,23 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
-public interface WatchListRepository extends JpaRepository<WatchList, Long> {}
+public interface WatchListRepository extends JpaRepository<WatchList, Long> {
+
+    @Query(
+            """
+		SELECT w
+		FROM watch_list w
+		JOIN FETCH w.match m
+		JOIN FETCH w.match.awayTeam at
+		JOIN FETCH w.match.homeTeam ht
+		JOIN FETCH w.match.stadium s
+		WHERE m.id = :id
+		""")
+    Page<WatchList> findAllByMatchId(Pageable pageable, Long id);
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
-public class WatchListRepository {}
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+
+public interface WatchListRepository extends JpaRepository<WatchList, Long> {}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,42 +1,12 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
-import java.util.Optional;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
-public interface WatchListRepository extends JpaRepository<WatchList, Long> {
-
-    @Query(
-            """
-		SELECT w
-		FROM watch_list w
-		JOIN FETCH w.match m
-		JOIN FETCH w.match.awayTeam at
-		JOIN FETCH w.match.homeTeam ht
-		JOIN FETCH w.match.stadium s
-		WHERE w.user.id = :userId
-		""")
-    Page<WatchList> findAllByUserIdWithMatchDetails(
-            @Param("userId") Long userId, Pageable pageable);
-
-    @Query(
-            """
-		SELECT w
-		FROM watch_list w
-		JOIN FETCH w.match m
-		JOIN FETCH w.match.awayTeam at
-		JOIN FETCH w.match.homeTeam ht
-		JOIN FETCH w.match.stadium s
-		WHERE w.id = :watchListId AND w.user.id = :userId
-		""")
-    Optional<WatchList> findByIdWithMatchDetails(
-            @Param("watchListId") Long watchListId, @Param("userId") Long userId);
+public interface WatchListRepository
+        extends JpaRepository<WatchList, Long>, WatchListQueryRepository {
 
     default WatchList findDetailByIdAndOwnerOrThrow(
             @Param("watchListId") Long watchListId, @Param("userId") Long userId) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,16 +1,16 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 
 public interface WatchListRepository
         extends JpaRepository<WatchList, Long>, WatchListQueryRepository {
 
-    default WatchList findDetailByIdAndOwnerOrThrow(
-            @Param("watchListId") Long watchListId, @Param("userId") Long userId) {
+    default WatchList findDetailByIdAndOwnerOrThrow(Long watchListId, Long userId) {
         return findByIdWithMatchDetails(watchListId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.WATCH_LIST_NOT_FOUN));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,7 +19,18 @@ public interface WatchListRepository extends JpaRepository<WatchList, Long> {
 		JOIN FETCH w.match.awayTeam at
 		JOIN FETCH w.match.homeTeam ht
 		JOIN FETCH w.match.stadium s
-		WHERE m.id = :id
 		""")
-    Page<WatchList> findAllByMatchId(Pageable pageable, Long id);
+    Page<WatchList> findAllWithMatchDetails(Pageable pageable);
+
+    @Query(
+            """
+		SELECT w
+		FROM watch_list w
+		JOIN FETCH w.match m
+		JOIN FETCH w.match.awayTeam at
+		JOIN FETCH w.match.homeTeam ht
+		JOIN FETCH w.match.stadium s
+		WHERE w.id = :id
+		""")
+    Optional<WatchList> findByIdWithMatchDetails(Long id);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -19,6 +19,12 @@ public class WatchListService {
     private final WatchListRepository watchListRepository;
     private final MatchRepository matchRepository;
 
+	/**
+	 * 직관 기록 등록 서비스
+	 *
+	 * @param request 유저 요청 객체
+	 * @return {@link CreateWatchListResponseDto}
+	 */
     public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
         Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
 

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -41,7 +41,7 @@ public class WatchListService {
 
         watchListRepository.save(watchList);
 
-        return CreateWatchListResponseDto.from(MatchScheduleDto.of(match), RecordDto.of(request));
+        return CreateWatchListResponseDto.from(match, request);
     }
 
     /**

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,5 +1,9 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
@@ -7,25 +11,23 @@ import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListReque
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import com.sparta.spartatigers.domain.watchlist.repository.WatchListRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class WatchListService {
 
-	private final WatchListRepository watchListRepository;
-	private final MatchRepository matchRepository;
+    private final WatchListRepository watchListRepository;
+    private final MatchRepository matchRepository;
 
-	public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
-		Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
+    public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
+        Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
 
-		WatchList watchList = WatchList.from(match, request);
-		watchListRepository.save(watchList);
+        WatchList watchList = WatchList.from(match, request);
+        watchListRepository.save(watchList);
 
-		MatchScheduleDto findMatch = MatchScheduleDto.of(match);
+        MatchScheduleDto findMatch = MatchScheduleDto.of(match);
 
-		return new CreateWatchListResponseDto(
-			findMatch, CreateWatchListResponseDto.RecordDto.of(request));
-	}
+        return new CreateWatchListResponseDto(
+                findMatch, CreateWatchListResponseDto.RecordDto.of(request));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -73,7 +73,8 @@ public class WatchListService {
     @Transactional(readOnly = true)
     public WatchListResponseDto findOne(Long watchListId, CustomUserPrincipal principal) {
         Long userId = principal.getUserId(principal);
-        WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
+        WatchList findWatchList =
+                watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
         return WatchListResponseDto.of(findWatchList);
     }
@@ -90,7 +91,8 @@ public class WatchListService {
     public WatchListResponseDto update(
             Long watchListId, UpdateWatchListRequestDto request, CustomUserPrincipal principal) {
         Long userId = principal.getUserId(principal);
-        WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
+        WatchList findWatchList =
+                watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
         findWatchList.update(request.getRecord().getContent(), request.getRecord().getRate());
 
@@ -106,7 +108,8 @@ public class WatchListService {
     @Transactional
     public void delete(Long watchListId, CustomUserPrincipal principal) {
         Long userId = principal.getUserId(principal);
-        WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
+        WatchList findWatchList =
+                watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
         watchListRepository.delete(findWatchList);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
+import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
@@ -23,9 +24,11 @@ public class WatchListService {
      * 직관 기록 등록 서비스
      *
      * @param request 유저 요청 객체
+	 * @param principal 유저 정보
      * @return {@link CreateWatchListResponseDto}
      */
-    public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
+    public CreateWatchListResponseDto create(
+            CreateWatchListRequestDto request, CustomUserPrincipal principal) {
         Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
         WatchList watchList = WatchList.from(match, request);
 

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -117,7 +117,7 @@ public class WatchListService {
      * @param principal 유저 정보
      * @return {@link Page<WatchListResponseDto>}
      */
-	@Transactional(readOnly = true)
+    @Transactional(readOnly = true)
     public Page<WatchListResponseDto> search(
             Pageable pageable, SearchWatchListRequestDto request, CustomUserPrincipal principal) {
         Long userId = CustomUserPrincipal.getUserId(principal);

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -53,7 +53,7 @@ public class WatchListService {
      */
     @Transactional(readOnly = true)
     public Page<WatchListResponseDto> findAll(Pageable pageable, CustomUserPrincipal principal) {
-        Long userId = principal.getUser().getId();
+        Long userId = principal.getUserId(principal);
         Page<WatchList> all = watchListRepository.findAllByUserIdWithMatchDetails(userId, pageable);
 
         if (all.isEmpty()) {
@@ -72,7 +72,7 @@ public class WatchListService {
      */
     @Transactional(readOnly = true)
     public WatchListResponseDto findOne(Long watchListId, CustomUserPrincipal principal) {
-        Long userId = getUserId(principal);
+        Long userId = principal.getUserId(principal);
         WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
 
         return WatchListResponseDto.of(findWatchList);
@@ -89,7 +89,7 @@ public class WatchListService {
     @Transactional
     public WatchListResponseDto update(
             Long watchListId, UpdateWatchListRequestDto request, CustomUserPrincipal principal) {
-        Long userId = getUserId(principal);
+        Long userId = principal.getUserId(principal);
         WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
 
         findWatchList.update(request.getRecord().getContent(), request.getRecord().getRate());
@@ -105,13 +105,9 @@ public class WatchListService {
      */
     @Transactional
     public void delete(Long watchListId, CustomUserPrincipal principal) {
-        Long userId = getUserId(principal);
+        Long userId = principal.getUserId(principal);
         WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
 
         watchListRepository.delete(findWatchList);
-    }
-
-    private Long getUserId(CustomUserPrincipal principal) {
-        return principal.getUser().getId();
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -7,11 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
-import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -11,6 +11,7 @@ import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.dto.request.SearchWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
@@ -106,5 +107,22 @@ public class WatchListService {
                 watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
         watchListRepository.delete(findWatchList);
+    }
+
+    /**
+     * 직관 기록 검색 서비스
+     *
+     * @param request 검색 요청 객체
+     * @param principal 유저 정보
+     * @return {@link Page<WatchListResponseDto>}
+     */
+    public Page<WatchListResponseDto> search(
+            Pageable pageable, SearchWatchListRequestDto request, CustomUserPrincipal principal) {
+        Long userId = principal.getUserId(principal);
+        Page<WatchList> all =
+                watchListRepository.findAllByKeyword(
+                        userId, request.getTeamName(), request.getStadiumName(), pageable);
+
+        return all.map(WatchListResponseDto::of);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -13,6 +13,7 @@ import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
@@ -71,6 +72,27 @@ public class WatchListService {
                 watchListRepository
                         .findByIdWithMatchDetails(watchListId)
                         .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+
+        return WatchListResponseDto.of(findWatchList);
+    }
+
+    /**
+     * 직관 기록 수정 서비스
+     *
+     * @param watchListId 직관 기록 식별자
+     * @param request 요청 DTO
+     * @param principal 유저 정보
+     * @return {@link WatchListResponseDto}
+     */
+    @Transactional
+    public WatchListResponseDto update(
+            Long watchListId, UpdateWatchListRequestDto request, CustomUserPrincipal principal) {
+        WatchList findWatchList =
+                watchListRepository
+                        .findByIdWithMatchDetails(watchListId)
+                        .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+
+        findWatchList.update(request.getRecord().getContent(), request.getRecord().getRate());
 
         return WatchListResponseDto.of(findWatchList);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -96,4 +96,20 @@ public class WatchListService {
 
         return WatchListResponseDto.of(findWatchList);
     }
+
+	/**
+	 * 직관 기록 삭제
+	 *
+	 * @param watchListId 직관 기록 식별자
+	 * @param principal 유저 정보
+	 */
+    @Transactional
+    public void delete(Long watchListId, CustomUserPrincipal principal) {
+        WatchList findWatchList =
+                watchListRepository
+                        .findByIdWithMatchDetails(watchListId)
+                        .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+
+        watchListRepository.delete(findWatchList);
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,5 +1,6 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class WatchListService {
 
         watchListRepository.save(watchList);
 
-        return CreateWatchListResponseDto.from(match, request);
+        return CreateWatchListResponseDto.from(match, RecordDto.of(request));
     }
 
     /**
@@ -52,7 +53,7 @@ public class WatchListService {
      */
     @Transactional(readOnly = true)
     public Page<WatchListResponseDto> findAll(Pageable pageable, CustomUserPrincipal principal) {
-        Long userId = principal.getUserId(principal);
+        Long userId = CustomUserPrincipal.getUserId(principal);
         Page<WatchList> all = watchListRepository.findAllByUserIdWithMatchDetails(userId, pageable);
 
         return all.map(WatchListResponseDto::of);
@@ -67,7 +68,7 @@ public class WatchListService {
      */
     @Transactional(readOnly = true)
     public WatchListResponseDto findOne(Long watchListId, CustomUserPrincipal principal) {
-        Long userId = principal.getUserId(principal);
+        Long userId = CustomUserPrincipal.getUserId(principal);
         WatchList findWatchList =
                 watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
@@ -85,7 +86,7 @@ public class WatchListService {
     @Transactional
     public WatchListResponseDto update(
             Long watchListId, UpdateWatchListRequestDto request, CustomUserPrincipal principal) {
-        Long userId = principal.getUserId(principal);
+        Long userId = CustomUserPrincipal.getUserId(principal);
         WatchList findWatchList =
                 watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
@@ -102,7 +103,7 @@ public class WatchListService {
      */
     @Transactional
     public void delete(Long watchListId, CustomUserPrincipal principal) {
-        Long userId = principal.getUserId(principal);
+        Long userId = CustomUserPrincipal.getUserId(principal);
         WatchList findWatchList =
                 watchListRepository.findDetailByIdAndOwnerOrThrow(watchListId, userId);
 
@@ -118,7 +119,7 @@ public class WatchListService {
      */
     public Page<WatchListResponseDto> search(
             Pageable pageable, SearchWatchListRequestDto request, CustomUserPrincipal principal) {
-        Long userId = principal.getUserId(principal);
+        Long userId = CustomUserPrincipal.getUserId(principal);
         Page<WatchList> all =
                 watchListRepository.findAllByKeyword(
                         userId, request.getTeamName(), request.getStadiumName(), pageable);

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,9 +1,31 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
-import org.springframework.stereotype.Service;
-
+import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
+import com.sparta.spartatigers.domain.match.model.entity.Match;
+import com.sparta.spartatigers.domain.match.repository.MatchRepository;
+import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+import com.sparta.spartatigers.domain.watchlist.repository.WatchListRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class WatchListService {}
+public class WatchListService {
+
+	private final WatchListRepository watchListRepository;
+	private final MatchRepository matchRepository;
+
+	public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
+		Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
+
+		WatchList watchList = WatchList.from(match, request);
+		watchListRepository.save(watchList);
+
+		MatchScheduleDto findMatch = MatchScheduleDto.of(match);
+
+		return new CreateWatchListResponseDto(
+			findMatch, CreateWatchListResponseDto.RecordDto.of(request));
+	}
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,6 +1,5 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
-import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -11,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.SearchWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -73,10 +73,7 @@ public class WatchListService {
     @Transactional(readOnly = true)
     public WatchListResponseDto findOne(Long watchListId, CustomUserPrincipal principal) {
         Long userId = getUserId(principal);
-        WatchList findWatchList =
-                watchListRepository
-                        .findByIdWithMatchDetails(watchListId, userId)
-                        .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+        WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
 
         return WatchListResponseDto.of(findWatchList);
     }
@@ -93,10 +90,7 @@ public class WatchListService {
     public WatchListResponseDto update(
             Long watchListId, UpdateWatchListRequestDto request, CustomUserPrincipal principal) {
         Long userId = getUserId(principal);
-        WatchList findWatchList =
-                watchListRepository
-                        .findByIdWithMatchDetails(watchListId, userId)
-                        .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+        WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
 
         findWatchList.update(request.getRecord().getContent(), request.getRecord().getRate());
 
@@ -112,10 +106,7 @@ public class WatchListService {
     @Transactional
     public void delete(Long watchListId, CustomUserPrincipal principal) {
         Long userId = getUserId(principal);
-        WatchList findWatchList =
-                watchListRepository
-                        .findByIdWithMatchDetails(watchListId, userId)
-                        .orElseThrow(() -> new IllegalArgumentException("기록 식별자가 존재하지 않습니다."));
+        WatchList findWatchList = watchListRepository.findByIdOrElseThrow(watchListId, userId);
 
         watchListRepository.delete(findWatchList);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -117,6 +117,7 @@ public class WatchListService {
      * @param principal 유저 정보
      * @return {@link Page<WatchListResponseDto>}
      */
+	@Transactional(readOnly = true)
     public Page<WatchListResponseDto> search(
             Pageable pageable, SearchWatchListRequestDto request, CustomUserPrincipal principal) {
         Long userId = CustomUserPrincipal.getUserId(principal);

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -32,6 +32,6 @@ public class WatchListService {
         watchListRepository.save(watchList);
 
         return CreateWatchListResponseDto.from(
-			MatchScheduleDto.of(match), CreateWatchListResponseDto.RecordDto.of(request));
+                MatchScheduleDto.of(match), CreateWatchListResponseDto.RecordDto.of(request));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -56,10 +56,6 @@ public class WatchListService {
         Long userId = principal.getUserId(principal);
         Page<WatchList> all = watchListRepository.findAllByUserIdWithMatchDetails(userId, pageable);
 
-        if (all.isEmpty()) {
-            return Page.empty();
-        }
-
         return all.map(WatchListResponseDto::of);
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import com.sparta.spartatigers.domain.watchlist.repository.WatchListRepository;
 
@@ -24,7 +27,7 @@ public class WatchListService {
      * 직관 기록 등록 서비스
      *
      * @param request 유저 요청 객체
-	 * @param principal 유저 정보
+     * @param principal 유저 정보
      * @return {@link CreateWatchListResponseDto}
      */
     public CreateWatchListResponseDto create(
@@ -36,5 +39,13 @@ public class WatchListService {
 
         return CreateWatchListResponseDto.from(
                 MatchScheduleDto.of(match), CreateWatchListResponseDto.RecordDto.of(request));
+    }
+
+    public Page<WatchListResponseDto> find(Pageable pageable) {
+        Page<WatchList> all = watchListRepository.findAllByMatchId(pageable, 1L);
+        if (all.isEmpty()) {
+            return Page.empty();
+        }
+        return all.map(WatchListResponseDto::of);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -18,6 +18,8 @@ import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResp
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import com.sparta.spartatigers.domain.watchlist.repository.WatchListRepository;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +39,9 @@ public class WatchListService {
     public CreateWatchListResponseDto create(
             CreateWatchListRequestDto request, CustomUserPrincipal principal) {
         Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
+        if (match == null) {
+            throw new InvalidRequestException(ExceptionCode.MATCH_NOT_FOUND);
+        }
         WatchList watchList = WatchList.from(match, request, principal.getUser());
 
         watchListRepository.save(watchList);

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -10,6 +10,7 @@ import com.sparta.spartatigers.domain.match.dto.MatchScheduleDto;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
+import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
@@ -37,8 +38,7 @@ public class WatchListService {
 
         watchListRepository.save(watchList);
 
-        return CreateWatchListResponseDto.from(
-                MatchScheduleDto.of(match), CreateWatchListResponseDto.RecordDto.of(request));
+        return CreateWatchListResponseDto.from(MatchScheduleDto.of(match), RecordDto.of(request));
     }
 
     public Page<WatchListResponseDto> find(Pageable pageable) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -27,13 +27,11 @@ public class WatchListService {
      */
     public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
         Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
-
         WatchList watchList = WatchList.from(match, request);
+
         watchListRepository.save(watchList);
 
-        MatchScheduleDto findMatch = MatchScheduleDto.of(match);
-
         return CreateWatchListResponseDto.from(
-                findMatch, CreateWatchListResponseDto.RecordDto.of(request));
+			MatchScheduleDto.of(match), CreateWatchListResponseDto.RecordDto.of(request));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -19,12 +19,12 @@ public class WatchListService {
     private final WatchListRepository watchListRepository;
     private final MatchRepository matchRepository;
 
-	/**
-	 * 직관 기록 등록 서비스
-	 *
-	 * @param request 유저 요청 객체
-	 * @return {@link CreateWatchListResponseDto}
-	 */
+    /**
+     * 직관 기록 등록 서비스
+     *
+     * @param request 유저 요청 객체
+     * @return {@link CreateWatchListResponseDto}
+     */
     public CreateWatchListResponseDto create(CreateWatchListRequestDto request) {
         Match match = matchRepository.findByIdWithTeamsAndStadium(request.getMatch().getId());
 
@@ -33,7 +33,7 @@ public class WatchListService {
 
         MatchScheduleDto findMatch = MatchScheduleDto.of(match);
 
-        return new CreateWatchListResponseDto(
+        return CreateWatchListResponseDto.from(
                 findMatch, CreateWatchListResponseDto.RecordDto.of(request));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -36,7 +36,7 @@ public enum ExceptionCode {
     ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
 
     // 직관 기록
-	WATCH_LIST_NOT_FOUN("직관 기록이 존재하지 않습니다."),
+    WATCH_LIST_NOT_FOUN("직관 기록이 존재하지 않습니다."),
 
     // 공통
     NOT_FOUND("not found ~~"),

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -36,7 +36,7 @@ public enum ExceptionCode {
     ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
 
     // 직관 기록
-    WATCH_LIST_NOT_FOUN("직관 기록이 존재하지 않습니다."),
+    WATCH_LIST_NOT_FOUND("직관 기록이 존재하지 않습니다."),
 
     // 공통
     NOT_FOUND("not found ~~"),

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -22,6 +22,9 @@ public enum ExceptionCode {
     NICKNAME_ALREADY_USED("이미 사용 중인 닉네임입니다."),
     ACCESS_DENIED("해당 계정의 접근 권한이 없습니다."),
 
+    // 경기
+    MATCH_NOT_FOUND("경기가 존재하지 않습니다."),
+
     // 라이브 보드
 
     // 알람

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -36,6 +36,7 @@ public enum ExceptionCode {
     ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
 
     // 직관 기록
+	WATCH_LIST_NOT_FOUN("직관 기록이 존재하지 않습니다."),
 
     // 공통
     NOT_FOUND("not found ~~"),

--- a/src/main/java/com/sparta/spartatigers/global/exception/InvalidRequestException.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/InvalidRequestException.java
@@ -1,22 +1,23 @@
 package com.sparta.spartatigers.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public class InvalidRequestException extends BaseException {
 
-	private final ExceptionCode exceptionCode;
+    private final ExceptionCode exceptionCode;
 
-	@Override
-	public HttpStatus getStatus() {
-		return HttpStatus.BAD_REQUEST;
-	}
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
 
-	@Override
-	public String getMessage() {
-		return exceptionCode.getMessage();
-	}
+    @Override
+    public String getMessage() {
+        return exceptionCode.getMessage();
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/global/exception/InvalidRequestException.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/InvalidRequestException.java
@@ -1,0 +1,22 @@
+package com.sparta.spartatigers.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class InvalidRequestException extends BaseException {
+
+	private final ExceptionCode exceptionCode;
+
+	@Override
+	public HttpStatus getStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+
+	@Override
+	public String getMessage() {
+		return exceptionCode.getMessage();
+	}
+}


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 직관 기록 등록, 단/다건 조회, 수정, 삭제, 검색 기능 구현

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- #3 

## 💬 기타 코멘트
- 아직 직관 기록 통계는 확실히 정해지지 않아서 구현하지 않았습니다.
- 도메인 전체를 이슈로 만들어서 양이 좀 많아요 죄송합니다..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 경기 시청 기록(WatchList) 관리 기능이 추가되었습니다. 사용자는 시청 기록을 생성, 조회(단일/목록/검색/페이지네이션), 수정, 삭제할 수 있습니다.
  - 시청 기록 검색 시 팀명 및 경기장명으로 필터링할 수 있습니다.
  - 각 시청 기록은 경기 정보와 평가(내용, 평점)를 포함합니다.
  - 모든 시청 기록 기능은 본인 인증 후 사용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->