### PR TITLE
[feat/exchange request] 티켓 & 굿즈 교환 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -2,7 +2,12 @@ package com.sparta.spartatigers.domain.exchangerequest.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ExchangeRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.service.ExchangeRequestService;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.global.response.ApiResponse;
@@ -31,5 +37,16 @@ public class ExchangeRequestController {
         exchangeRequestService.createExchangeRequest(request, principal);
 
         return ApiResponse.created(MessageCode.EXCHANGE_REQUEST_SUCCESS.getMessage());
+    }
+
+    @GetMapping("/send")
+    public ApiResponse<Page<ExchangeRequestResponseDto>> findAllSendRequest(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+        Page<ExchangeRequestResponseDto> response =
+                exchangeRequestService.findAllSendRequest(principal, pageable);
+
+        return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -75,4 +75,14 @@ public class ExchangeRequestController {
 
         return ApiResponse.ok(MessageCode.UPDATE_EXCHANGE_REQUEST_SUCCESS.getMessage());
     }
+
+    @PatchMapping("/{exchangeRequestId}/complete")
+    public ApiResponse<String> completeExchange(
+            @PathVariable Long exchangeRequestId,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+
+        exchangeRequestService.completeExchange(exchangeRequestId, principal);
+
+        return ApiResponse.ok(MessageCode.COMPLETE_EXCHANGE_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -16,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
-import com.sparta.spartatigers.domain.exchangerequest.dto.response.ExchangeRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.SendRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.service.ExchangeRequestService;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.global.response.ApiResponse;
@@ -40,12 +41,23 @@ public class ExchangeRequestController {
     }
 
     @GetMapping("/send")
-    public ApiResponse<Page<ExchangeRequestResponseDto>> findAllSendRequest(
+    public ApiResponse<Page<SendRequestResponseDto>> findAllSendRequest(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
 
-        Page<ExchangeRequestResponseDto> response =
+        Page<SendRequestResponseDto> response =
                 exchangeRequestService.findAllSendRequest(principal, pageable);
+
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/receive")
+    public ApiResponse<Page<ReceiveRequestResponseDto>> findAllReceiveRequest(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+        Page<ReceiveRequestResponseDto> response =
+                exchangeRequestService.findAllReceiveRequest(principal, pageable);
 
         return ApiResponse.ok(response);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.SendRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.service.ExchangeRequestService;
@@ -60,5 +63,16 @@ public class ExchangeRequestController {
                 exchangeRequestService.findAllReceiveRequest(principal, pageable);
 
         return ApiResponse.ok(response);
+    }
+
+    @PatchMapping("/{exchangeRequestId}")
+    public ApiResponse<String> updateRequestStatus(
+            @PathVariable Long exchangeRequestId,
+            @Valid @RequestBody UpdateExchangeRequestDto request,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+
+        exchangeRequestService.updateRequestStatus(exchangeRequestId, request, principal);
+
+        return ApiResponse.ok(MessageCode.UPDATE_EXCHANGE_REQUEST_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/UpdateExchangeRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/UpdateExchangeRequestDto.java
@@ -1,0 +1,8 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+
+public record UpdateExchangeRequestDto(
+        @NotNull(message = "변경할 상태값은 필수입니다.") ExchangeRequest.ExchangeStatus status) {}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ExchangeRequestResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ExchangeRequestResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Category;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
+import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
+
+public record ExchangeRequestResponseDto(
+        Long exchangeRequestId,
+        UserResponseDto receiver,
+        Category category,
+        String title,
+        Status status,
+        LocalDateTime createdAt) {
+
+    public static ExchangeRequestResponseDto from(ExchangeRequest exchangeRequest) {
+
+        return new ExchangeRequestResponseDto(
+                exchangeRequest.getId(),
+                UserResponseDto.from(exchangeRequest.getReceiver()),
+                exchangeRequest.getItem().getCategory(),
+                exchangeRequest.getItem().getTitle(),
+                exchangeRequest.getItem().getStatus(),
+                exchangeRequest.getItem().getCreatedAt());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ReceiveRequestResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ReceiveRequestResponseDto.java
@@ -23,6 +23,6 @@ public record ReceiveRequestResponseDto(
                 exchangeRequest.getItem().getCategory(),
                 exchangeRequest.getItem().getTitle(),
                 exchangeRequest.getItem().getStatus(),
-                exchangeRequest.getItem().getCreatedAt());
+                exchangeRequest.getCreatedAt());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ReceiveRequestResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ReceiveRequestResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Category;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
+import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
+
+public record ReceiveRequestResponseDto(
+        Long exchangeRequestId,
+        UserResponseDto sender,
+        Category category,
+        String title,
+        Status status,
+        LocalDateTime createdAt) {
+
+    public static ReceiveRequestResponseDto from(ExchangeRequest exchangeRequest) {
+
+        return new ReceiveRequestResponseDto(
+                exchangeRequest.getId(),
+                UserResponseDto.from(exchangeRequest.getSender()),
+                exchangeRequest.getItem().getCategory(),
+                exchangeRequest.getItem().getTitle(),
+                exchangeRequest.getItem().getStatus(),
+                exchangeRequest.getItem().getCreatedAt());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/SendRequestResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/SendRequestResponseDto.java
@@ -23,6 +23,6 @@ public record SendRequestResponseDto(
                 exchangeRequest.getItem().getCategory(),
                 exchangeRequest.getItem().getTitle(),
                 exchangeRequest.getItem().getStatus(),
-                exchangeRequest.getItem().getCreatedAt());
+                exchangeRequest.getCreatedAt());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/SendRequestResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/SendRequestResponseDto.java
@@ -7,7 +7,7 @@ import com.sparta.spartatigers.domain.item.model.entity.Item.Category;
 import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
 import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
 
-public record ExchangeRequestResponseDto(
+public record SendRequestResponseDto(
         Long exchangeRequestId,
         UserResponseDto receiver,
         Category category,
@@ -15,9 +15,9 @@ public record ExchangeRequestResponseDto(
         Status status,
         LocalDateTime createdAt) {
 
-    public static ExchangeRequestResponseDto from(ExchangeRequest exchangeRequest) {
+    public static SendRequestResponseDto from(ExchangeRequest exchangeRequest) {
 
-        return new ExchangeRequestResponseDto(
+        return new SendRequestResponseDto(
                 exchangeRequest.getId(),
                 UserResponseDto.from(exchangeRequest.getReceiver()),
                 exchangeRequest.getItem().getCategory(),

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/entity/ExchangeRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/entity/ExchangeRequest.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.exchangerequest.model.entity;
 
+import java.util.stream.Stream;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,6 +18,8 @@ import com.sparta.spartatigers.domain.item.model.entity.Item;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.global.exception.ExceptionCode;
 import com.sparta.spartatigers.global.exception.ServerException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 @Entity(name = "exchange_request")
 @Getter
@@ -57,6 +61,16 @@ public class ExchangeRequest extends BaseEntity {
     public enum ExchangeStatus {
         PENDING,
         ACCEPTED,
-        REJECTED
+        REJECTED;
+
+        @JsonCreator
+        public static ExchangeStatus parsing(String inputValue) {
+            return Stream.of(ExchangeStatus.values())
+                    .filter(
+                            exchangeStatus ->
+                                    exchangeStatus.toString().equals(inputValue.toUpperCase()))
+                    .findFirst()
+                    .orElse(null);
+        }
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/entity/ExchangeRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/entity/ExchangeRequest.java
@@ -14,6 +14,8 @@ import lombok.NoArgsConstructor;
 import com.sparta.spartatigers.domain.common.entity.BaseEntity;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
 import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
 
 @Entity(name = "exchange_request")
 @Getter
@@ -39,6 +41,17 @@ public class ExchangeRequest extends BaseEntity {
     public static ExchangeRequest of(Item item, User sender, User receiver) {
 
         return new ExchangeRequest(item, sender, receiver, ExchangeStatus.PENDING);
+    }
+
+    public void validateReceiverIsOwner(User receiver) {
+
+        if (!this.receiver.getId().equals(receiver.getId())) {
+            throw new ServerException(ExceptionCode.RECEIVER_FORBIDDEN);
+        }
+    }
+
+    public void updateStatus(ExchangeStatus status) {
+        this.status = status;
     }
 
     public enum ExchangeStatus {

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
@@ -1,9 +1,14 @@
 package com.sparta.spartatigers.domain.exchangerequest.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest.ExchangeStatus;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
 
 public interface ExchangeRequestQueryRepository {
 
@@ -12,4 +17,12 @@ public interface ExchangeRequestQueryRepository {
     Page<ExchangeRequest> findAllSendRequest(Long senderId, Pageable pageable);
 
     Page<ExchangeRequest> findAllReceiveRequest(Long receiverId, Pageable pageable);
+
+    Optional<ExchangeRequest> findExchangeRequestById(
+            Long exchangeRequestId, ExchangeStatus status);
+
+    default ExchangeRequest findExchangeRequestByIdOrElseThrow(Long exchangeRequestId) {
+        return findExchangeRequestById(exchangeRequestId, ExchangeStatus.PENDING)
+                .orElseThrow(() -> new ServerException(ExceptionCode.EXCHANGE_REQUEST_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
@@ -25,4 +25,9 @@ public interface ExchangeRequestQueryRepository {
         return findExchangeRequestById(exchangeRequestId, ExchangeStatus.PENDING)
                 .orElseThrow(() -> new ServerException(ExceptionCode.EXCHANGE_REQUEST_NOT_FOUND));
     }
+
+    default ExchangeRequest findAcceptedRequestByIdOrElseThrow(Long exchangeRequestId) {
+        return findExchangeRequestById(exchangeRequestId, ExchangeStatus.ACCEPTED)
+                .orElseThrow(() -> new ServerException(ExceptionCode.EXCHANGE_REQUEST_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
@@ -10,4 +10,6 @@ public interface ExchangeRequestQueryRepository {
     boolean findExchangeRequest(Long senderId, Long receiverId, Long itemId);
 
     Page<ExchangeRequest> findAllSendRequest(Long senderId, Pageable pageable);
+
+    Page<ExchangeRequest> findAllReceiveRequest(Long receiverId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepository.java
@@ -1,6 +1,13 @@
 package com.sparta.spartatigers.domain.exchangerequest.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+
 public interface ExchangeRequestQueryRepository {
 
     boolean findExchangeRequest(Long senderId, Long receiverId, Long itemId);
+
+    Page<ExchangeRequest> findAllSendRequest(Long senderId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepositoryImpl.java
@@ -71,6 +71,36 @@ public class ExchangeRequestQueryRepositoryImpl implements ExchangeRequestQueryR
         return new PageImpl<>(exchangeRequestList, pageable, count);
     }
 
+    @Override
+    public Page<ExchangeRequest> findAllReceiveRequest(Long receiverId, Pageable pageable) {
+
+        List<ExchangeRequest> exchangeRequestList =
+                queryFactory
+                        .selectFrom(exchangeRequest)
+                        .join(exchangeRequest.sender, sender)
+                        .fetchJoin()
+                        .join(exchangeRequest.receiver, receiver)
+                        .fetchJoin()
+                        .join(exchangeRequest.item, item)
+                        .fetchJoin()
+                        .where(receiverIdEq(receiverId))
+                        .orderBy(exchangeRequest.createdAt.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        Long total =
+                queryFactory
+                        .select(exchangeRequest.count())
+                        .from(exchangeRequest)
+                        .where(receiverIdEq(receiverId))
+                        .fetchOne();
+
+        long count = (total == null) ? 0L : total;
+
+        return new PageImpl<>(exchangeRequestList, pageable, count);
+    }
+
     private BooleanExpression senderIdEq(Long senderId) {
 
         return sender.id.eq(senderId);

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.sparta.spartatigers.domain.exchangerequest.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest.ExchangeStatus;
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.QExchangeRequest;
 import com.sparta.spartatigers.domain.item.model.entity.QItem;
 import com.sparta.spartatigers.domain.user.model.entity.QUser;
@@ -101,6 +103,25 @@ public class ExchangeRequestQueryRepositoryImpl implements ExchangeRequestQueryR
         return new PageImpl<>(exchangeRequestList, pageable, count);
     }
 
+    @Override
+    public Optional<ExchangeRequest> findExchangeRequestById(
+            Long exchangeRequestId, ExchangeStatus status) {
+
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(exchangeRequest)
+                        .where(
+                                exchangeRequestIdEq(exchangeRequestId),
+                                exchangeRequestStatusEq(status))
+                        .join(exchangeRequest.sender, sender)
+                        .fetchJoin()
+                        .join(exchangeRequest.receiver, receiver)
+                        .fetchJoin()
+                        .join(exchangeRequest.item, item)
+                        .fetchJoin()
+                        .fetchOne());
+    }
+
     private BooleanExpression senderIdEq(Long senderId) {
 
         return sender.id.eq(senderId);
@@ -114,5 +135,15 @@ public class ExchangeRequestQueryRepositoryImpl implements ExchangeRequestQueryR
     private BooleanExpression itemIdEq(Long itemId) {
 
         return item.id.eq(itemId);
+    }
+
+    private BooleanExpression exchangeRequestIdEq(Long exchangeRequestId) {
+
+        return exchangeRequest.id.eq(exchangeRequestId);
+    }
+
+    private BooleanExpression exchangeRequestStatusEq(ExchangeStatus status) {
+
+        return exchangeRequest.status.eq(status);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -1,11 +1,14 @@
 package com.sparta.spartatigers.domain.exchangerequest.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ExchangeRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
 import com.sparta.spartatigers.domain.exchangerequest.repository.ExchangeRequestRepository;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
@@ -39,6 +42,18 @@ public class ExchangeRequestService {
         ExchangeRequest exchangeRequest = ExchangeRequest.of(requestItem, sender, receiver);
 
         exchangeRequestRepository.save(exchangeRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ExchangeRequestResponseDto> findAllSendRequest(
+            CustomUserPrincipal principal, Pageable pageable) {
+
+        User user = principal.getUser();
+
+        Page<ExchangeRequest> exchangeRequestList =
+                exchangeRequestRepository.findAllSendRequest(user.getId(), pageable);
+
+        return exchangeRequestList.map(ExchangeRequestResponseDto::from);
     }
 
     private User getReceiver(Long receiverId) {

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -91,6 +91,19 @@ public class ExchangeRequestService {
         }
     }
 
+    @Transactional
+    public void completeExchange(Long exchangeRequestId, CustomUserPrincipal principal) {
+
+        User user = principal.getUser();
+
+        ExchangeRequest exchangeRequest =
+                exchangeRequestRepository.findAcceptedRequestByIdOrElseThrow(exchangeRequestId);
+        exchangeRequest.validateReceiverIsOwner(user);
+
+        Item item = itemRepository.findItemByIdOrElseThrow(exchangeRequest.getItem().getId());
+        item.complete();
+    }
+
     private User getReceiver(Long receiverId) {
 
         return userRepository

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -8,7 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
-import com.sparta.spartatigers.domain.exchangerequest.dto.response.ExchangeRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.SendRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
 import com.sparta.spartatigers.domain.exchangerequest.repository.ExchangeRequestRepository;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
@@ -45,7 +46,7 @@ public class ExchangeRequestService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ExchangeRequestResponseDto> findAllSendRequest(
+    public Page<SendRequestResponseDto> findAllSendRequest(
             CustomUserPrincipal principal, Pageable pageable) {
 
         User user = principal.getUser();
@@ -53,7 +54,19 @@ public class ExchangeRequestService {
         Page<ExchangeRequest> exchangeRequestList =
                 exchangeRequestRepository.findAllSendRequest(user.getId(), pageable);
 
-        return exchangeRequestList.map(ExchangeRequestResponseDto::from);
+        return exchangeRequestList.map(SendRequestResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReceiveRequestResponseDto> findAllReceiveRequest(
+            CustomUserPrincipal principal, Pageable pageable) {
+
+        User user = principal.getUser();
+
+        Page<ExchangeRequest> exchangeRequestList =
+                exchangeRequestRepository.findAllReceiveRequest(user.getId(), pageable);
+
+        return exchangeRequestList.map(ReceiveRequestResponseDto::from);
     }
 
     private User getReceiver(Long receiverId) {

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.SendRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
@@ -67,6 +68,20 @@ public class ExchangeRequestService {
                 exchangeRequestRepository.findAllReceiveRequest(user.getId(), pageable);
 
         return exchangeRequestList.map(ReceiveRequestResponseDto::from);
+    }
+
+    @Transactional
+    public void updateRequestStatus(
+            Long exchangeRequestId,
+            UpdateExchangeRequestDto request,
+            CustomUserPrincipal principal) {
+
+        User user = principal.getUser();
+
+        ExchangeRequest exchangeRequest =
+                exchangeRequestRepository.findExchangeRequestByIdOrElseThrow(exchangeRequestId);
+        exchangeRequest.validateReceiverIsOwner(user);
+        exchangeRequest.updateStatus(request.status());
     }
 
     private User getReceiver(Long receiverId) {

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -101,6 +101,8 @@ public class ExchangeRequestService {
         exchangeRequest.validateReceiverIsOwner(user);
 
         Item item = itemRepository.findItemByIdOrElseThrow(exchangeRequest.getItem().getId());
+        // 현재 교환 완료는 Item의 상태(COMPLETED)로 관리
+        // ExchangeRequest는 (ACCEPTED) 상태까지만 관리
         item.complete();
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -7,11 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.sparta.spartatigers.domain.chatroom.service.DirectRoomService;
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.SendRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest.ExchangeStatus;
 import com.sparta.spartatigers.domain.exchangerequest.repository.ExchangeRequestRepository;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
 import com.sparta.spartatigers.domain.item.repository.ItemRepository;
@@ -28,6 +30,7 @@ public class ExchangeRequestService {
     private final ExchangeRequestRepository exchangeRequestRepository;
     private final ItemRepository itemRepository;
     private final UserRepository userRepository;
+    private final DirectRoomService directRoomService;
 
     @Transactional
     public void createExchangeRequest(ExchangeRequestDto request, CustomUserPrincipal principal) {
@@ -82,6 +85,10 @@ public class ExchangeRequestService {
                 exchangeRequestRepository.findExchangeRequestByIdOrElseThrow(exchangeRequestId);
         exchangeRequest.validateReceiverIsOwner(user);
         exchangeRequest.updateStatus(request.status());
+
+        if (exchangeRequest.getStatus() == ExchangeStatus.ACCEPTED) {
+            directRoomService.createRoom(exchangeRequestId, user.getId());
+        }
     }
 
     private User getReceiver(Long receiverId) {

--- a/src/main/java/com/sparta/spartatigers/domain/item/model/entity/Item.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/model/entity/Item.java
@@ -73,6 +73,10 @@ public class Item extends BaseEntity {
         }
     }
 
+    public void complete() {
+        this.status = Status.COMPLETED;
+    }
+
     public enum Category {
         GOODS,
         TICKET;

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -37,6 +37,7 @@ public enum ExceptionCode {
     ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
     CANNOT_REQUEST_OWN_ITEM("자신의 아이템에 대해 교환 요청을 할 수 없습니다."),
     RECEIVER_NOT_OWNER("해당 아이템의 소유자에게만 요청을 보낼 수 있습니다."),
+    RECEIVER_FORBIDDEN("요청을 받은 사용자만 요청을 수정할 수 있습니다."),
 
     // 직관 기록
 

--- a/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
@@ -20,6 +20,7 @@ public enum MessageCode {
     // 교환 요청
     EXCHANGE_REQUEST_SUCCESS("교환 요청을 성공적으로 보냈습니다."),
     UPDATE_EXCHANGE_REQUEST_SUCCESS("교환 요청 상태 변경을 성공했습니다."),
+    COMPLETE_EXCHANGE_SUCCESS("교환을 성공적으로 완료했습니다."),
 
 // 아이템
 

--- a/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
@@ -19,6 +19,7 @@ public enum MessageCode {
 
     // 교환 요청
     EXCHANGE_REQUEST_SUCCESS("교환 요청을 성공적으로 보냈습니다."),
+    UPDATE_EXCHANGE_REQUEST_SUCCESS("교환 요청 상태 변경을 성공했습니다."),
 
 // 아이템
 


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 보낸 교환 요청 목록 조회 기능
  - 생성일을 기준으로 내림차순 조회
- 받은 교환 요청 목록 조회 기능
  - 생성일을 기준으로 내림차순 조회
- 교환 요청 상태 변경 기능
  - 교환 요청 글을 올린 사람만 변경 가능
  - 교환 요청 상태가 PENDING인 경우에만 변경 가능
  - 교환 요청 상태가 ACCEPTED일 때 채팅방 생성
- 교환 종료 기능
  - 교환 요청 글을 올린 사람만 변경 가능
  - 교환 요청 상태가 ACCEPTED일 때만 교환 종료 가능
  - 아이템 상태가 PENDING일 때만 교환 종료 가능

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- close #29 
- close #30 
- close #31 
- close #58 

## 💬 기타 코멘트
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 교환 요청의 보낸 목록과 받은 목록을 페이지네이션으로 조회할 수 있는 기능이 추가되었습니다.
  - 교환 요청 상태를 변경하거나 교환을 완료 처리할 수 있는 기능이 추가되었습니다.

- **버그 수정**
  - 교환 요청 수정 권한이 요청을 받은 사용자에게만 허용되도록 개선되었습니다.

- **메시지 및 예외 코드**
  - 교환 요청 상태 변경 및 교환 완료에 대한 성공 메시지가 추가되었습니다.
  - 요청을 받은 사용자만 수정할 수 있음을 알리는 예외 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->