### PR TITLE
[feat/watchlist] 직관 기록 통계 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/repository/UserRepository.java
@@ -5,9 +5,16 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    default User findByIdOrElseThrow(Long userId) {
+        return findById(userId)
+                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -124,4 +124,9 @@ public class WatchListController {
         Pageable pageable = PageRequest.of(page, size);
         return ApiResponse.ok(watchListService.search(pageable, request, principal));
     }
+
+    @GetMapping("/stats")
+    public ApiResponse<?> getStats(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ApiResponse.ok(watchListService.getStats(principal));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/StatsResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/StatsResponseDto.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.sparta.spartatigers.domain.watchlist.service.StatsAccumulator;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,4 +16,15 @@ public class StatsResponseDto {
     private String mostVisitStadium;
     private String bestWinRateStadium;
     private int win, draw, lose;
+
+    public static StatsResponseDto of(StatsAccumulator accumulator) {
+        return new StatsResponseDto(
+                accumulator.getTotal(),
+                accumulator.getWinRate(),
+                accumulator.getMostVisitedStadium(),
+                accumulator.getBestWinRateStadium(),
+                accumulator.getWin(),
+                accumulator.getDraw(),
+                accumulator.getLose());
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/StatsResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/StatsResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.spartatigers.domain.watchlist.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatsResponseDto {
+
+    private int total;
+    private double winRate;
+    private String mostVisitStadium;
+    private String bestWinRateStadium;
+    private int win, draw, lose;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/StatsResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/response/StatsResponseDto.java
@@ -13,7 +13,7 @@ public class StatsResponseDto {
 
     private int total;
     private double winRate;
-    private String mostVisitStadium;
+    private String mostVisitedStadium;
     private String bestWinRateStadium;
     private int win, draw, lose;
 

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -26,6 +26,7 @@ public interface WatchListRepository
 		JOIN FETCH w.user
 		JOIN FETCH w.match.homeTeam
 		JOIN FETCH w.match.awayTeam
+		WHERE w.user = :user
 		""")
     List<WatchList> findAllByUser(User user);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -1,7 +1,11 @@
 package com.sparta.spartatigers.domain.watchlist.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import com.sparta.spartatigers.global.exception.ExceptionCode;
 import com.sparta.spartatigers.global.exception.InvalidRequestException;
@@ -13,4 +17,15 @@ public interface WatchListRepository
         return findByIdWithMatchDetails(watchListId, userId)
                 .orElseThrow(() -> new InvalidRequestException(ExceptionCode.WATCH_LIST_NOT_FOUND));
     }
+
+    @Query(
+		"""
+		SELECT w
+		FROM watch_list w
+		JOIN FETCH w.match
+		JOIN FETCH w.user
+		JOIN FETCH w.match.homeTeam
+		JOIN FETCH w.match.awayTeam
+		""")
+    List<WatchList> findAllByUser(User user);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/repository/WatchListRepository.java
@@ -19,7 +19,7 @@ public interface WatchListRepository
     }
 
     @Query(
-		"""
+            """
 		SELECT w
 		FROM watch_list w
 		JOIN FETCH w.match

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/StatsAccumulator.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/StatsAccumulator.java
@@ -1,0 +1,104 @@
+package com.sparta.spartatigers.domain.watchlist.service;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import lombok.Getter;
+
+import com.sparta.spartatigers.domain.match.model.entity.Match;
+import com.sparta.spartatigers.domain.match.model.entity.Match.MatchResult;
+import com.sparta.spartatigers.domain.team.model.entity.Team;
+import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
+
+@Getter
+public class StatsAccumulator {
+    private static final int MIN_VISITS = 3;
+
+    private final Team favoriteTeam;
+    private int total = 0;
+    private int win = 0;
+    private int draw = 0;
+    private int lose = 0;
+    private final Map<String, Integer> stadiumVisitCount = new HashMap<>();
+    private final Map<String, int[]> stadiumWdl = new HashMap<>(); // [win, total]
+
+    public StatsAccumulator(Team favoriteTeam) {
+        this.favoriteTeam = favoriteTeam;
+    }
+
+    public void accumulate(WatchList watchList) {
+        Match match = watchList.getMatch();
+        // 취소 경기 제외
+        if (match.getMatchResult() == MatchResult.CANCEL) {
+            return;
+        }
+
+        String stadiumName = match.getStadium().getName();
+        stadiumVisitCount.put(stadiumName, stadiumVisitCount.getOrDefault(stadiumName, 0) + 1);
+
+        stadiumWdl.putIfAbsent(stadiumName, new int[2]);
+        int[] wdlArr = stadiumWdl.get(stadiumName);
+
+        MatchResult myResult = determineResult(match);
+        if (myResult == null) {
+            return;
+        }
+
+        updateStats(myResult, wdlArr);
+    }
+
+    public double getWinRate() {
+        return total > 0 ? (win * 100.0) / total : 0.0;
+    }
+
+    public String getMostVisitedStadium() {
+        return stadiumVisitCount.entrySet().stream()
+                .max(Entry.comparingByValue())
+                .map(Entry::getKey)
+                .orElse(null);
+    }
+
+    public String getBestWinRateStadium() {
+        return stadiumWdl.entrySet().stream()
+                .filter(e -> e.getValue()[1] >= MIN_VISITS)
+                .max(Comparator.comparingDouble(e -> (double) e.getValue()[0] / e.getValue()[1]))
+                .map(Entry::getKey)
+                .orElse(null);
+    }
+
+    private MatchResult determineResult(Match match) {
+        boolean isHome = match.getHomeTeam().equals(favoriteTeam);
+        boolean isAway = match.getAwayTeam().equals(favoriteTeam);
+
+        if (!isHome && !isAway) return null;
+
+        MatchResult result = match.getMatchResult();
+        if (isHome) return result;
+
+        // Away일 경우 결과를 뒤집는다
+        return switch (result) {
+            case HOME_WIN -> MatchResult.AWAY_WIN;
+            case AWAY_WIN -> MatchResult.HOME_WIN;
+            default -> result;
+        };
+    }
+
+    private void updateStats(MatchResult result, int[] wdlArr) {
+        switch (result) {
+            case HOME_WIN:
+                win++;
+                wdlArr[0]++;
+                break;
+            case AWAY_WIN:
+                lose++;
+                break;
+            case DRAW:
+                draw++;
+                break;
+        }
+        total++;
+        wdlArr[1]++; // 방문 수 증가
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,9 +1,6 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -145,6 +142,12 @@ public class WatchListService {
         return all.map(WatchListResponseDto::of);
     }
 
+	/**
+	 * 응원하는 팀에 한정하여 직관 통계 데이터를 제공하는 서비스
+	 *
+	 * @param principal 유저 정보
+	 * @return {@link StatsResponseDto}
+	 */
     @Transactional(readOnly = true)
     public StatsResponseDto getStats(CustomUserPrincipal principal) {
         Long userId = CustomUserPrincipal.getUserId(principal);
@@ -155,78 +158,11 @@ public class WatchListService {
 
         List<WatchList> watchLists = watchListRepository.findAllByUser(user);
 
-        int total = watchLists.size();
-        int win = 0, draw = 0, lose = 0;
-
-        Map<String, Integer> stadiumVisitCount = new HashMap<>();
-        Map<String, int[]> stadiumWdl = new HashMap<>(); // [win, total]
-
+        StatsAccumulator accumulator = new StatsAccumulator(myTeam);
         for (WatchList wl : watchLists) {
-            Match match = wl.getMatch();
-            if (match.getMatchResult().equals(Match.MatchResult.CANCEL)) {
-                continue; // 취소 경기 제외
-            }
-
-            // 경기장 방문 집계
-            String stadiumName = match.getStadium().getName();
-            stadiumVisitCount.put(stadiumName, stadiumVisitCount.getOrDefault(stadiumName, 0) + 1);
-
-            // 경기장별 승리 집계
-            stadiumWdl.putIfAbsent(stadiumName, new int[2]);
-            int[] wdlArr = stadiumWdl.get(stadiumName);
-
-            // 승/무/패 판정
-            Match.MatchResult result = match.getMatchResult();
-            boolean isHome = match.getHomeTeam().equals(myTeam);
-            boolean isAway = match.getAwayTeam().equals(myTeam);
-
-            // FavoriteTeam이 해당 경기 참가 안함
-            if (!isHome && !isAway) {
-                continue;
-            }
-
-            Match.MatchResult myResult;
-            if (isHome) {
-                myResult = result;
-            } else {
-                // Away 기준으로 뒤집기
-                if (result == Match.MatchResult.HOME_WIN) myResult = Match.MatchResult.AWAY_WIN;
-                else if (result == Match.MatchResult.AWAY_WIN)
-                    myResult = Match.MatchResult.HOME_WIN;
-                else myResult = result;
-            }
-
-            if (myResult == Match.MatchResult.HOME_WIN) { // 내팀이 이김
-                win++;
-                wdlArr[0]++;
-            } else if (myResult == Match.MatchResult.AWAY_WIN) { // 내팀이 짐
-                lose++;
-            } else if (myResult == Match.MatchResult.DRAW) {
-                draw++;
-            }
-            wdlArr[1]++; // 방문 수
+            accumulator.accumulate(wl);
         }
 
-        // 가장 많이 방문한 경기장
-        String mostVisitedStadium =
-                stadiumVisitCount.entrySet().stream()
-                        .max(Map.Entry.comparingByValue())
-                        .map(Map.Entry::getKey)
-                        .orElse(null);
-
-        // 가장 승률이 좋은 경기장 (3회 이상 방문 기준)
-        String bestWinRateStadium =
-                stadiumWdl.entrySet().stream()
-                        .filter(e -> e.getValue()[1] >= 3)
-                        .max(
-                                Comparator.comparingDouble(
-                                        e -> (double) e.getValue()[0] / e.getValue()[1]))
-                        .map(Map.Entry::getKey)
-                        .orElse(null);
-
-        double winRate = total > 0 ? (win * 100.0) / total : 0.0;
-
-        return new StatsResponseDto(
-                total, winRate, mostVisitedStadium, bestWinRateStadium, win, draw, lose);
+        return StatsResponseDto.of(accumulator);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -1,5 +1,10 @@
 package com.sparta.spartatigers.domain.watchlist.service;
 
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -7,13 +12,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.sparta.spartatigers.domain.favoriteteam.model.entity.FavoriteTeam;
+import com.sparta.spartatigers.domain.favoriteteam.repository.FavoriteTeamRepository;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
+import com.sparta.spartatigers.domain.team.model.entity.Team;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
+import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.SearchWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.StatsResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 import com.sparta.spartatigers.domain.watchlist.repository.WatchListRepository;
@@ -26,6 +37,8 @@ public class WatchListService {
 
     private final WatchListRepository watchListRepository;
     private final MatchRepository matchRepository;
+    private final FavoriteTeamRepository favoriteTeamRepository;
+    private final UserRepository userRepository;
 
     /**
      * 직관 기록 등록 서비스
@@ -130,5 +143,90 @@ public class WatchListService {
                         userId, request.getTeamName(), request.getStadiumName(), pageable);
 
         return all.map(WatchListResponseDto::of);
+    }
+
+    @Transactional(readOnly = true)
+    public StatsResponseDto getStats(CustomUserPrincipal principal) {
+        Long userId = CustomUserPrincipal.getUserId(principal);
+
+        User user = userRepository.findByIdOrElseThrow(userId);
+        FavoriteTeam favoriteTeam = favoriteTeamRepository.findByUserIdOrElseThrow(userId);
+        Team myTeam = favoriteTeam.getTeam();
+
+        List<WatchList> watchLists = watchListRepository.findAllByUser(user);
+
+        int total = watchLists.size();
+        int win = 0, draw = 0, lose = 0;
+
+        Map<String, Integer> stadiumVisitCount = new HashMap<>();
+        Map<String, int[]> stadiumWdl = new HashMap<>(); // [win, total]
+
+        for (WatchList wl : watchLists) {
+            Match match = wl.getMatch();
+            if (match.getMatchResult().equals(Match.MatchResult.CANCEL)) {
+                continue; // 취소 경기 제외
+            }
+
+            // 경기장 방문 집계
+            String stadiumName = match.getStadium().getName();
+            stadiumVisitCount.put(stadiumName, stadiumVisitCount.getOrDefault(stadiumName, 0) + 1);
+
+            // 경기장별 승리 집계
+            stadiumWdl.putIfAbsent(stadiumName, new int[2]);
+            int[] wdlArr = stadiumWdl.get(stadiumName);
+
+            // 승/무/패 판정
+            Match.MatchResult result = match.getMatchResult();
+            boolean isHome = match.getHomeTeam().equals(myTeam);
+            boolean isAway = match.getAwayTeam().equals(myTeam);
+
+            // FavoriteTeam이 해당 경기 참가 안함
+            if (!isHome && !isAway) {
+                continue;
+            }
+
+            Match.MatchResult myResult;
+            if (isHome) {
+                myResult = result;
+            } else {
+                // Away 기준으로 뒤집기
+                if (result == Match.MatchResult.HOME_WIN) myResult = Match.MatchResult.AWAY_WIN;
+                else if (result == Match.MatchResult.AWAY_WIN)
+                    myResult = Match.MatchResult.HOME_WIN;
+                else myResult = result;
+            }
+
+            if (myResult == Match.MatchResult.HOME_WIN) { // 내팀이 이김
+                win++;
+                wdlArr[0]++;
+            } else if (myResult == Match.MatchResult.AWAY_WIN) { // 내팀이 짐
+                lose++;
+            } else if (myResult == Match.MatchResult.DRAW) {
+                draw++;
+            }
+            wdlArr[1]++; // 방문 수
+        }
+
+        // 가장 많이 방문한 경기장
+        String mostVisitedStadium =
+                stadiumVisitCount.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .map(Map.Entry::getKey)
+                        .orElse(null);
+
+        // 가장 승률이 좋은 경기장 (3회 이상 방문 기준)
+        String bestWinRateStadium =
+                stadiumWdl.entrySet().stream()
+                        .filter(e -> e.getValue()[1] >= 3)
+                        .max(
+                                Comparator.comparingDouble(
+                                        e -> (double) e.getValue()[0] / e.getValue()[1]))
+                        .map(Map.Entry::getKey)
+                        .orElse(null);
+
+        double winRate = total > 0 ? (win * 100.0) / total : 0.0;
+
+        return new StatsResponseDto(
+                total, winRate, mostVisitedStadium, bestWinRateStadium, win, draw, lose);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/service/WatchListService.java
@@ -142,12 +142,12 @@ public class WatchListService {
         return all.map(WatchListResponseDto::of);
     }
 
-	/**
-	 * 응원하는 팀에 한정하여 직관 통계 데이터를 제공하는 서비스
-	 *
-	 * @param principal 유저 정보
-	 * @return {@link StatsResponseDto}
-	 */
+    /**
+     * 응원하는 팀에 한정하여 직관 통계 데이터를 제공하는 서비스
+     *
+     * @param principal 유저 정보
+     * @return {@link StatsResponseDto}
+     */
     @Transactional(readOnly = true)
     public StatsResponseDto getStats(CustomUserPrincipal principal) {
         Long userId = CustomUserPrincipal.getUserId(principal);


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 사용자가 등록한 응원하는 팀에 대해서만 직관 통계 정보를 제공함
- 제공 데이터는 다음과 같음
  - 총 방문 수
  - 직관 승률
  - 가장 많이 방문한 구장
  - 가장 승률이 높은 구장
  - 직관한 경기의 승/무/패

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- closes #63 
- #3 

## 💬 기타 코멘트
- 현재는 응원하는 팀에 대한 데이터만 통계를 내고있어서
  응원하지 않는 팀의 경기를 직관 기록에 등록하면 통계 데이터에 잡히지는 않습니다
- 추후에 전체 통계 / 응원 팀 통계로 확장 계획에 있습니다. 
  - #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 사용자의 즐겨찾기 팀을 기준으로 관전 기록 통계(총 경기 수, 승률, 최다 방문 경기장, 최고 승률 경기장, 승/무/패 수)를 조회하는 새로운 통계 조회 엔드포인트가 추가되었습니다.
    - 사용자 ID로 조회 시 사용자를 찾지 못할 경우 예외를 발생시키는 기능이 추가되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->