### PR TITLE
[Refactor/liveboard] 채팅방 입퇴장시 접속자 수 카운트 구현방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     // 웹 애플리케이션 (REST API 포함)
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // WebSocket (실시간 통신)
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
+    // Redisson (Redis 분산락)
 
     // === 데이터베이스 드라이버 ===
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -103,3 +105,5 @@ clean {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardInterceptor.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardInterceptor.java
@@ -1,0 +1,62 @@
+package com.sparta.spartatigers.domain.liveboard.controller;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import com.sparta.spartatigers.domain.liveboard.service.LiveBoardService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LiveBoardInterceptor implements ChannelInterceptor {
+
+	private final LiveBoardService liveBoardService;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message); // stomp 메세지의 헤더를 분석 ( 커멘드, 세션아이디 등등..)
+		StompCommand command = accessor.getCommand();
+
+		// 채팅방 구독시
+		if (StompCommand.SUBSCRIBE.equals(command)){
+			String destination = accessor.getDestination(); // url
+			String sessionId = accessor.getSessionId(); // 세션 id
+
+			if(destination != null && destination.startsWith("/server/liveboard/room/")) {
+				String enterRoomId = destination.substring("/server/liveboard/room/".length());
+				String lastRoomId = redisTemplate.opsForValue().get(sessionId);
+
+				// 다른 채팅방에서 넘어온 경우
+				if (lastRoomId != null && !lastRoomId.equals(enterRoomId)) {
+					liveBoardService.decreaseConnectCount(lastRoomId);
+				}
+
+				// 새로 입장한 채팅방 접속자 수 증가
+				liveBoardService.increaseConnectCount(enterRoomId);
+				redisTemplate.opsForValue().set(sessionId, enterRoomId);
+			}
+		}
+
+		// 웹소켓 연결 종료시
+		if(StompCommand.DISCONNECT.equals(command)){
+			String sessionId = accessor.getSessionId();
+			String roomId = redisTemplate.opsForValue().get(sessionId);
+
+			if (roomId != null) {
+				liveBoardService.decreaseConnectCount(roomId);
+				redisTemplate.delete(sessionId);
+			}
+		}
+		return message;
+	}
+
+
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardMessageController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardMessageController.java
@@ -17,17 +17,14 @@ public class LiveBoardMessageController {
     private final RedisMessagePublisher redisPublisher;
     private final LiveBoardService liveBoardService;
 
-    @MessageMapping("/chat/message")
+    @MessageMapping("/liveboard/message")
     public void sendMessage(LiveBoardMessage message) {
         String roomId = message.getRoomId();
-
         ChannelTopic topic = liveBoardService.getTopic(roomId);
         if (topic == null) {
             liveBoardService.enterRoom(roomId);
             topic = liveBoardService.getTopic(roomId);
         }
-
-        liveBoardService.updateConnectCount(message);
         redisPublisher.publish(topic, message);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/model/LiveBoardMessage.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/model/LiveBoardMessage.java
@@ -14,7 +14,6 @@ public class LiveBoardMessage {
     private String senderNickname;
     private String content; // 내용
     private LocalDateTime sentAt;
-    private MessageType type;
 
     public LiveBoardMessage() {
         this.sentAt = LocalDateTime.now();

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/model/MessageType.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/model/MessageType.java
@@ -1,7 +1,0 @@
-package com.sparta.spartatigers.domain.liveboard.model;
-
-public enum MessageType {
-    TALK, // 일반 메시지
-    ENTER, // 입장
-    QUIT // 퇴장
-}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/pubsub/RedisMessageSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/pubsub/RedisMessageSubscriber.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class RedisMessageSubscriber implements MessageListener {
 
     private final ObjectMapper objectMapper;
-    private final RedisTemplate redisTemplate;
+    private final RedisTemplate<String,String> redisTemplate;
     private final SimpMessageSendingOperations messagingTemplate;
 
     @Override
@@ -32,7 +32,7 @@ public class RedisMessageSubscriber implements MessageListener {
                     objectMapper.readValue(publishMessage, LiveBoardMessage.class);
 
             messagingTemplate.convertAndSend(
-                    "/server/chat/room/" + liveBoardMessage.getRoomId(), liveBoardMessage);
+                    "/server/liveboard/room/" + liveBoardMessage.getRoomId(), liveBoardMessage);
         } catch (Exception e) {
             log.error(e.getMessage());
         }

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/repository/LiveBoardRoomRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/repository/LiveBoardRoomRepository.java
@@ -32,9 +32,7 @@ public class LiveBoardRoomRepository {
     }
 
     public void saveRoom(LiveBoardRoom room) {
-        log.info("[🔄] Redis 저장 시도: {}", room.getRoomId());
         opsHash.put(LIVEBOARD_ROOMS, room.getRoomId(), room);
-        log.info("[✅] Redis 저장 성공: {}", room.getRoomId());
     }
 
     public LiveBoardRoom findRoomById(String roomId) {

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/scheduler/LiveBoardScheduler.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/scheduler/LiveBoardScheduler.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import com.sparta.spartatigers.domain.liveboard.service.LiveBoardService;
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
-import com.sparta.spartatigers.domain.team.model.entity.Team;
 import com.sparta.spartatigers.domain.team.repository.TeamRepository;
 
 @Slf4j
@@ -48,7 +47,7 @@ public class LiveBoardScheduler {
         // // ✅ 1. Team 저장
         // Team homeTeam = teamRepository.save(Team.builder().name("한화").build());
         // Team awayTeam = teamRepository.save(Team.builder().name("기아").build());
-		//
+        //
         // // ✅ 2. 저장된 Team으로 Match 생성
         // Match dummyMatch =
         //         Match.builder()
@@ -57,10 +56,10 @@ public class LiveBoardScheduler {
         //                 .awayTeam(awayTeam) // ✔️ 여기!
         //                 .stadium(null)
         //                 .build();
-		//
+        //
         // // ✅ 3. Match 저장
         // Match savedMatch = matchRepository.save(dummyMatch);
-		//
+        //
         // // ✅ 4. Redis용 채팅방 생성
         // List<Match> todayMatches = List.of(savedMatch); // ✔️ savedMatch 써야 roomId 가능
         // liveBoardService.createTodayRoom(todayMatches);

--- a/src/main/java/com/sparta/spartatigers/global/config/RedissonConfig.java
+++ b/src/main/java/com/sparta/spartatigers/global/config/RedissonConfig.java
@@ -1,0 +1,25 @@
+package com.sparta.spartatigers.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/config/WebSocketConfig.java
+++ b/src/main/java/com/sparta/spartatigers/global/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.sparta.spartatigers.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -9,6 +10,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 import lombok.RequiredArgsConstructor;
 
+import com.sparta.spartatigers.domain.liveboard.controller.LiveBoardInterceptor;
 import com.sparta.spartatigers.global.handler.DefaultWebSocketHandshakeHandler;
 
 /**
@@ -20,6 +22,8 @@ import com.sparta.spartatigers.global.handler.DefaultWebSocketHandshakeHandler;
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final LiveBoardInterceptor liveBoardInterceptor;
 
     /**
      * /ws로 연결 요청을 보내도록 설정 javaScipt ex) const socket = new SockJS('/ws'); withSockJS WebSocket을
@@ -40,7 +44,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // @MessageMapping(liveboard.)
+        // @MessageMapping("/liveboard.")
         // @MessageMapping("/dm.")
         // js ex) stompClinet.subscribe('/topic/chat/')
         registry.enableSimpleBroker("/server");
@@ -50,4 +54,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     // 추후 참고할 만한 코드: https://modutaxi-tech.tistory.com/6
 
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(liveBoardInterceptor);
+	}
 }


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
-  채팅방 접속자 수 카운트 방식을 변경했습니다

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [x] 관련 문서 수정

## 🔗 관련 이슈
- #43 (하단 기존 방식으로 동시성 이슈 해결한 커밋있음)
- #64 

## 💬 기타 코멘트

**🚫 기존 방식**
1. sendMessage()가 호출되면 enterRoom()을 통해 해당 roomId의 ChannelTopic을 등록한 후, 메시지를 Redis로 publish함

2. 이 과정에서 message.type == ENTER이면 접속자 수 증가 처리도 같이했음 (updateConnectCount(message))

3. 문제는 **메시지를 하나라도 보내야 접속자 수가 증가함**
사용자가 채팅방에 입장했어도 아무 메시지를 보내지 않으면 접속자 수에 포함되지 않음

+ 다수의 사용자가 동시에 입장할 경우 connectCount를 업데이트하는 과정에서 동시성 이슈가 발생했으며, 이를 Redisson 분산 락으로 해결함 (근데 버림,,,)

---

**✅ 현재 방식**
1. STOMP 프로토콜 흐름 중 SUBSCRIBE 명령이 감지되면, 
Interceptor에서 destination을 파싱하여 접속자 수를 바로 증가 처리

2. 채팅 메시지를 보내지 않아도, 채팅방 구독과 동시에 접속자 수에 반영

3. 문제는 UNSUBSCRIBE 또는 DISCONNECT 일때는 **destination이 null**이기 때문에 
어떤 방에서 나간 것인지 알 수 없음

4. 이를 해결하기 위해 **sessionId ↔ roomId 매핑을 Redis에 저장**
+ 구독할 때 sessionId → roomId를 저장

5. **연결 종료 뿐만 아니라 다른 채팅방으로 이동시에도 정확하게 접속자 수를 증감처리 할 수 있음**
