### PR TITLE
[feat/exchange request] 교환 완료 시 채팅방 및 메시지 삭제 #79

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/model/entity/DirectRoom.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/model/entity/DirectRoom.java
@@ -34,6 +34,7 @@ public class DirectRoom extends BaseEntity {
     @JoinColumn(name = "receiver_id", nullable = false)
     private User receiver;
 
+    // TODO: 나중에 확장 기능에서 교환 완료 시점에 채팅방을 readOnly로 바꿀 수 있게 보류
     @Column(nullable = false)
     private boolean isCompleted = false;
 

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/repository/DirectMessageRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/repository/DirectMessageRepository.java
@@ -13,4 +13,6 @@ public interface DirectMessageRepository extends JpaRepository<DirectMessage, Lo
     @Query("SELECT m FROM direct_message m JOIN FETCH m.sender WHERE m.directRoom.id = :roomId")
     Page<DirectMessage> findByDirectRoomIdWithSender(
             @Param("roomId") Long roomId, Pageable pageable);
+
+    void deleteAllByDirectRoomId(Long directRoomId);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/repository/DirectRoomRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/repository/DirectRoomRepository.java
@@ -24,4 +24,6 @@ public interface DirectRoomRepository extends JpaRepository<DirectRoom, Long> {
                     "select count(dr) from direct_rooms dr "
                             + "where dr.sender.id = :userId or dr.receiver.id = :userId")
     Page<DirectRoom> findBySenderIdOrReceiverIdWithUsers(Long userId, Pageable pageable);
+
+    Optional<DirectRoom> findByExchangeRequestId(Long exchangeRequestId);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/entity/ExchangeRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/entity/ExchangeRequest.java
@@ -58,10 +58,15 @@ public class ExchangeRequest extends BaseEntity {
         this.status = status;
     }
 
+    public void complete() {
+        this.status = ExchangeStatus.COMPLETED;
+    }
+
     public enum ExchangeStatus {
         PENDING,
         ACCEPTED,
-        REJECTED;
+        REJECTED,
+        COMPLETED;
 
         @JsonCreator
         public static ExchangeStatus parsing(String inputValue) {

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -101,9 +101,10 @@ public class ExchangeRequestService {
         exchangeRequest.validateReceiverIsOwner(user);
 
         Item item = itemRepository.findItemByIdOrElseThrow(exchangeRequest.getItem().getId());
-        // 현재 교환 완료는 Item의 상태(COMPLETED)로 관리
-        // ExchangeRequest는 (ACCEPTED) 상태까지만 관리
         item.complete();
+        exchangeRequest.complete();
+
+        directRoomService.deleteRoomByExchangeRequestId(exchangeRequestId);
     }
 
     private User getReceiver(Long receiverId) {


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- DirectMessageRepository에 deleteAllByDirectRoomId(Long roomId) 추가
- deleteRoomByExchangeRequestId에서 메시지 먼저 삭제 후 채팅방 삭제

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- #79 

## 💬 기타 코멘트
- x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 교환 요청 완료 상태(COMPLETED) 추가 및 교환 요청을 완료로 표시하는 기능이 도입되었습니다.

- **버그 수정**
  - 교환 요청이 완료될 때 관련 채팅방 및 모든 메시지가 함께 삭제되어 데이터가 깔끔하게 정리됩니다.

- **기타**
  - 교환 요청 완료 시 채팅방을 읽기 전용으로 전환하는 향후 개선 사항이 주석으로 안내되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->