### PR TITLE
feat/direct message 채팅 기능 메시지 중복 수신 문제 해결 #100

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/chat-tester.html
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/chat-tester.html
@@ -34,6 +34,12 @@
   let stompClient = null;
 
   function connect() {
+    // 이미 연결되어 있으면 재연결 막기
+    if (stompClient && stompClient.connected) {
+      alert("이미 WebSocket에 연결되어 있습니다.");
+      return;
+    }
+
     const token = document.getElementById("token").value.trim();
     if (!token || !token.startsWith("Bearer ")) {
       alert("유효한 JWT 토큰을 입력하세요. 'Bearer ' 포함해야 합니다.");
@@ -83,7 +89,6 @@
         })
     );
   }
-
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- RedisUserSessionRegistry에서 registerSession 시 기존 세션 제거 후 새 세션만 등록되도록 변경
- 한 유저가 여러 디바이스 또는 탭에서 접속할 경우 메시지를 중복 수신하는 문제를 방지
- 테스트 프론트 코드 웹소켓 연결 중복 방지 코드

## ✅ 체크리스트
- [x] 테스트 완료
- [x] 코드 리뷰 반영
- [x] 관련 문서 수정

## 🔗 관련 이슈
- #100 

## 💬 기타 코멘트
- 향후 멀티 디바이스 지원 필요 시 멀티 세션 허용 + 메시지 중복 제거 로직 도입 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 중복된 WebSocket 연결 시도를 방지하여 이미 연결된 경우 사용자에게 알림을 표시하도록 개선되었습니다.
  - 한 사용자가 동시에 여러 세션을 가질 수 없도록 기존 세션을 모두 제거한 후 새 세션만 유지하도록 변경되었습니다.

- **문서화**
  - 멀티 세션 지원 관련 주석이 추가 및 정비되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->