### PR TITLE
[feat/item] 야구장 근처에서만 티켓 & 굿즈 등록이 가능하도록 로직 추가

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
-import com.sparta.spartatigers.domain.item.dto.request.CreateItemRequestDto;
+import com.sparta.spartatigers.domain.item.dto.request.CreateItemWithLocationRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.CreateItemResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemResponseDto;
@@ -33,7 +33,7 @@ public class ItemController {
 
     @PostMapping
     public ApiResponse<CreateItemResponseDto> createItem(
-            @Valid @RequestBody CreateItemRequestDto request,
+            @Valid @RequestBody CreateItemWithLocationRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
 
         CreateItemResponseDto response = itemService.createItem(request, userPrincipal);

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/request/CreateItemWithLocationRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/request/CreateItemWithLocationRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.spartatigers.domain.item.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateItemWithLocationRequestDto {
+
+    private CreateItemRequestDto itemDto;
+    private LocationRequestDto locationDto;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/team/model/entity/Stadium.java
+++ b/src/main/java/com/sparta/spartatigers/domain/team/model/entity/Stadium.java
@@ -16,4 +16,6 @@ import com.sparta.spartatigers.domain.common.entity.BaseEntity;
 public class Stadium extends BaseEntity {
 
     @Column private String name;
+    @Column private double latitude;
+    @Column private double longitude;
 }

--- a/src/main/java/com/sparta/spartatigers/domain/team/repository/StadiumRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/team/repository/StadiumRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.spartatigers.domain.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.spartatigers.domain.team.model.entity.Stadium;
+
+public interface StadiumRepository extends JpaRepository<Stadium, Long> {}

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -43,6 +43,7 @@ public enum ExceptionCode {
     CANNOT_REQUEST_OWN_ITEM("자신의 아이템에 대해 교환 요청을 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     RECEIVER_NOT_OWNER("해당 아이템의 소유자에게만 요청을 보낼 수 있습니다.", HttpStatus.FORBIDDEN),
     RECEIVER_FORBIDDEN("요청을 받은 사용자만 요청을 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+    LOCATION_NOT_VALID("아이템은 야구장 근처에서만 등록할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
     // 직관 기록
     WATCH_LIST_NOT_FOUND("직관 기록이 존재하지 않습니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- stadium 엔티티에 latitude, longitude 속성 추가
- 야구장에서 1km 이내에 있는 경우만 아이템 등록이 가능
- 아이템 등록 시 requestDto를 CreateItemWithLocationRequestDto로 변경
  - CreateItemWithLocationRequestDto = CreateItemRequestDto + LocationRequestDto

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- close #105 

## 💬 기타 코멘트
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 아이템 등록 시 위치 정보 입력이 추가되었습니다.
  - 야구장 반경 1km 이내에서만 아이템을 등록할 수 있도록 제한되었습니다.
- **버그 수정**
  - 위치가 야구장 근처가 아닐 경우, 아이템 등록 시도 시 오류 메시지가 제공됩니다.
- **기타**
  - 야구장 위치 정보가 시스템에 저장 및 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->