### PR TITLE
feat/direct message 채팅 기능 redis 세션 관리 방법 변경 #103

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectMessageController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectMessageController.java
@@ -1,5 +1,10 @@
 package com.sparta.spartatigers.domain.chatroom.controller;
 
+import com.sparta.spartatigers.domain.chatroom.dto.response.DirectRoomMessageResponse;
+import com.sparta.spartatigers.domain.chatroom.service.DirectMessageService;
+import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
+import com.sparta.spartatigers.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -10,35 +15,28 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import lombok.RequiredArgsConstructor;
-
-import com.sparta.spartatigers.domain.chatroom.dto.response.DirectRoomMessageResponse;
-import com.sparta.spartatigers.domain.chatroom.service.DirectMessageService;
-import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
-import com.sparta.spartatigers.global.response.ApiResponse;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/direct-rooms")
 public class DirectMessageController {
 
-    private final DirectMessageService directMessageService;
+	private final DirectMessageService directMessageService;
 
-    @GetMapping("/{roomId}/messages")
-    public ApiResponse<Page<DirectRoomMessageResponse>> getMessages(
-            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
-            @PathVariable Long roomId,
-            @PageableDefault(
-                            size = 100,
-                            sort = {"sentAt", "id"},
-                            direction = Sort.Direction.DESC)
-                    Pageable pageable) {
+	@GetMapping("/{roomId}/messages")
+	public ApiResponse<Page<DirectRoomMessageResponse>> getMessages(
+		@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+		@PathVariable Long roomId,
+		@PageableDefault(
+			size = 20,
+			sort = {"sentAt", "id"},
+			direction = Sort.Direction.DESC)
+		Pageable pageable) {
 
-        Long currentUserId = userPrincipal.getUser().getId();
+		Long currentUserId = userPrincipal.getUser().getId();
 
-        Page<DirectRoomMessageResponse> messages =
-                directMessageService.getMessages(roomId, currentUserId, pageable);
+		Page<DirectRoomMessageResponse> messages =
+			directMessageService.getMessages(roomId, currentUserId, pageable);
 
-        return ApiResponse.ok(messages);
-    }
+		return ApiResponse.ok(messages);
+	}
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectMessageController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectMessageController.java
@@ -1,10 +1,5 @@
 package com.sparta.spartatigers.domain.chatroom.controller;
 
-import com.sparta.spartatigers.domain.chatroom.dto.response.DirectRoomMessageResponse;
-import com.sparta.spartatigers.domain.chatroom.service.DirectMessageService;
-import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
-import com.sparta.spartatigers.global.response.ApiResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -15,28 +10,35 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.domain.chatroom.dto.response.DirectRoomMessageResponse;
+import com.sparta.spartatigers.domain.chatroom.service.DirectMessageService;
+import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
+import com.sparta.spartatigers.global.response.ApiResponse;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/direct-rooms")
 public class DirectMessageController {
 
-	private final DirectMessageService directMessageService;
+    private final DirectMessageService directMessageService;
 
-	@GetMapping("/{roomId}/messages")
-	public ApiResponse<Page<DirectRoomMessageResponse>> getMessages(
-		@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
-		@PathVariable Long roomId,
-		@PageableDefault(
-			size = 20,
-			sort = {"sentAt", "id"},
-			direction = Sort.Direction.DESC)
-		Pageable pageable) {
+    @GetMapping("/{roomId}/messages")
+    public ApiResponse<Page<DirectRoomMessageResponse>> getMessages(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @PathVariable Long roomId,
+            @PageableDefault(
+                            size = 20,
+                            sort = {"sentAt", "id"},
+                            direction = Sort.Direction.DESC)
+                    Pageable pageable) {
 
-		Long currentUserId = userPrincipal.getUser().getId();
+        Long currentUserId = userPrincipal.getUser().getId();
 
-		Page<DirectRoomMessageResponse> messages =
-			directMessageService.getMessages(roomId, currentUserId, pageable);
+        Page<DirectRoomMessageResponse> messages =
+                directMessageService.getMessages(roomId, currentUserId, pageable);
 
-		return ApiResponse.ok(messages);
-	}
+        return ApiResponse.ok(messages);
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectMessageController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectMessageController.java
@@ -29,7 +29,7 @@ public class DirectMessageController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
             @PathVariable Long roomId,
             @PageableDefault(
-                            size = 20,
+                            size = 30,
                             sort = {"sentAt", "id"},
                             direction = Sort.Direction.DESC)
                     Pageable pageable) {

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
@@ -27,7 +27,7 @@ public class RedisUserSessionRegistry {
         if (existingSessions != null) {
             for (String oldSessionId : existingSessions) {
                 redisTemplate.opsForSet().remove(userKey, oldSessionId);
-                redisTemplate.opsForHash().delete(SESSION_USER_KEY, oldSessionId);
+                redisTemplate.delete("session-user:" + oldSessionId);
             }
         }
 

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
@@ -2,70 +2,70 @@ package com.sparta.spartatigers.domain.chatroom.registry;
 
 import java.time.Duration;
 import java.util.Set;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class RedisUserSessionRegistry {
 
-    private static final String USER_SESSION_KEY_PREFIX =
-            "user-sessions:"; // userId -> Set<sessionId>
-    private static final String SESSION_USER_KEY = "session-users"; // sessionId -> userId
-    private final StringRedisTemplate redisTemplate;
+	private static final String USER_SESSION_KEY_PREFIX =
+		"user-sessions:"; // userId -> Set<sessionId>
+	private static final String SESSION_USER_KEY = "session-users"; // sessionId -> userId
+	private final StringRedisTemplate redisTemplate;
 
-    // 멀티 세션 불가 x (메시지 중복 수신 문제 발생)
-    // TODO: 추후에 멀티 디바이스 환경에도 사용할 수 있게 하려면 멀티 세션이 가능하게 대응
-    public void registerSession(Long userId, String sessionId) {
-        String userKey = USER_SESSION_KEY_PREFIX + userId;
+	// 멀티 세션 불가 x (메시지 중복 수신 문제 발생)
+	// TODO: 추후에 멀티 디바이스 환경에도 사용할 수 있게 하려면 멀티 세션이 가능하게 대응
+	public void registerSession(Long userId, String sessionId) {
+		String userKey = USER_SESSION_KEY_PREFIX + userId;
 
-        // 기존 세션 제거
-        Set<String> existingSessions = getSessionIds(userId);
-        if (existingSessions != null) {
-            for (String oldSessionId : existingSessions) {
-                redisTemplate.opsForSet().remove(userKey, oldSessionId);
-                redisTemplate.opsForHash().delete(SESSION_USER_KEY, oldSessionId);
-            }
-        }
+		// 기존 세션 제거
+		Set<String> existingSessions = getSessionIds(userId);
+		if (existingSessions != null) {
+			for (String oldSessionId : existingSessions) {
+				redisTemplate.opsForSet().remove(userKey, oldSessionId);
+				redisTemplate.opsForHash().delete(SESSION_USER_KEY, oldSessionId);
+			}
+		}
 
-        // 새 세션 등록
-        // userId별로 세션ID를 Set에 추가
-        redisTemplate.opsForSet().add(userKey, sessionId);
-        redisTemplate.expire(userKey, Duration.ofHours(6)); // 세션 만료 시간 설정
-        // 세션ID에 userId 해시에 등록
-        redisTemplate.opsForHash().put(SESSION_USER_KEY, sessionId, userId.toString());
-    }
+		// 새 세션 등록
+		// userId별로 세션ID를 Set에 추가
+		redisTemplate.opsForSet().add(userKey, sessionId);
+		redisTemplate.expire(userKey, Duration.ofHours(6)); // 세션 만료 시간 설정
+		// Sting Key로 관리
+		String sessionKey = "session-user:" + sessionId;
+		redisTemplate.opsForValue().set(sessionKey, userId.toString(), Duration.ofHours(6));
+	}
 
-    public void unregisterSession(Long userId, String sessionId) {
-        String userKey = USER_SESSION_KEY_PREFIX + userId;
+	public void unregisterSession(Long userId, String sessionId) {
+		String userKey = USER_SESSION_KEY_PREFIX + userId;
 
-        // Set에서 세션ID 제거
-        redisTemplate.opsForSet().remove(userKey, sessionId);
-        // 해시에서 세션ID 제거
-        redisTemplate.opsForHash().delete(SESSION_USER_KEY, sessionId);
+		// Set에서 세션ID 제거
+		redisTemplate.opsForSet().remove(userKey, sessionId);
+		// 세션ID 제거
+		redisTemplate.delete("session-user:" + sessionId);
 
-        // 세션이 모두 제거되면 키 자체 제거
-        if (Boolean.TRUE.equals(redisTemplate.opsForSet().size(userKey) == 0)) {
-            redisTemplate.delete(userKey);
-        }
-    }
+		// 세션이 모두 제거되면 키 자체 제거
+		if (Boolean.TRUE.equals(redisTemplate.opsForSet().size(userKey) == 0)) {
+			redisTemplate.delete(userKey);
+		}
+	}
 
-    public boolean isUserConnected(Long userId) {
-        String userKey = USER_SESSION_KEY_PREFIX + userId;
-        // userKey가 Redis에 존재하는지 확인
-        return Boolean.TRUE.equals(redisTemplate.hasKey(userKey));
-    }
+	public boolean isUserConnected(Long userId) {
+		String userKey = USER_SESSION_KEY_PREFIX + userId;
+		// userKey가 Redis에 존재하는지 확인
+		return Boolean.TRUE.equals(redisTemplate.hasKey(userKey));
+	}
 
-    public Long getUserIdBySessionId(String sessionId) {
-        Object userId = redisTemplate.opsForHash().get(SESSION_USER_KEY, sessionId);
-        return userId != null ? Long.parseLong(userId.toString()) : null;
-    }
+	public Long getUserIdBySessionId(String sessionId) {
+		String sessionKey = "session-user:" + sessionId;
+		String userId = redisTemplate.opsForValue().get(sessionKey);
+		return userId != null ? Long.parseLong(userId) : null;
+	}
 
-    public Set<String> getSessionIds(Long userId) {
-        String userKey = USER_SESSION_KEY_PREFIX + userId;
-        return redisTemplate.opsForSet().members(userKey);
-    }
+	public Set<String> getSessionIds(Long userId) {
+		String userKey = USER_SESSION_KEY_PREFIX + userId;
+		return redisTemplate.opsForSet().members(userKey);
+	}
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
@@ -2,70 +2,72 @@ package com.sparta.spartatigers.domain.chatroom.registry;
 
 import java.time.Duration;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class RedisUserSessionRegistry {
 
-	private static final String USER_SESSION_KEY_PREFIX =
-		"user-sessions:"; // userId -> Set<sessionId>
-	private static final String SESSION_USER_KEY = "session-users"; // sessionId -> userId
-	private final StringRedisTemplate redisTemplate;
+    private static final String USER_SESSION_KEY_PREFIX =
+            "user-sessions:"; // userId -> Set<sessionId>
+    private static final String SESSION_USER_KEY = "session-users"; // sessionId -> userId
+    private final StringRedisTemplate redisTemplate;
 
-	// 멀티 세션 불가 x (메시지 중복 수신 문제 발생)
-	// TODO: 추후에 멀티 디바이스 환경에도 사용할 수 있게 하려면 멀티 세션이 가능하게 대응
-	public void registerSession(Long userId, String sessionId) {
-		String userKey = USER_SESSION_KEY_PREFIX + userId;
+    // 멀티 세션 불가 x (메시지 중복 수신 문제 발생)
+    // TODO: 추후에 멀티 디바이스 환경에도 사용할 수 있게 하려면 멀티 세션이 가능하게 대응
+    public void registerSession(Long userId, String sessionId) {
+        String userKey = USER_SESSION_KEY_PREFIX + userId;
 
-		// 기존 세션 제거
-		Set<String> existingSessions = getSessionIds(userId);
-		if (existingSessions != null) {
-			for (String oldSessionId : existingSessions) {
-				redisTemplate.opsForSet().remove(userKey, oldSessionId);
-				redisTemplate.opsForHash().delete(SESSION_USER_KEY, oldSessionId);
-			}
-		}
+        // 기존 세션 제거
+        Set<String> existingSessions = getSessionIds(userId);
+        if (existingSessions != null) {
+            for (String oldSessionId : existingSessions) {
+                redisTemplate.opsForSet().remove(userKey, oldSessionId);
+                redisTemplate.opsForHash().delete(SESSION_USER_KEY, oldSessionId);
+            }
+        }
 
-		// 새 세션 등록
-		// userId별로 세션ID를 Set에 추가
-		redisTemplate.opsForSet().add(userKey, sessionId);
-		redisTemplate.expire(userKey, Duration.ofHours(6)); // 세션 만료 시간 설정
-		// 단일 키 구조로 변경
-		String sessionKey = "session-user:" + sessionId;
-		redisTemplate.opsForValue().set(sessionKey, userId.toString(), Duration.ofHours(6));
-	}
+        // 새 세션 등록
+        // userId별로 세션ID를 Set에 추가
+        redisTemplate.opsForSet().add(userKey, sessionId);
+        redisTemplate.expire(userKey, Duration.ofHours(6)); // 세션 만료 시간 설정
+        // 단일 키 구조로 변경
+        String sessionKey = "session-user:" + sessionId;
+        redisTemplate.opsForValue().set(sessionKey, userId.toString(), Duration.ofHours(6));
+    }
 
-	public void unregisterSession(Long userId, String sessionId) {
-		String userKey = USER_SESSION_KEY_PREFIX + userId;
+    public void unregisterSession(Long userId, String sessionId) {
+        String userKey = USER_SESSION_KEY_PREFIX + userId;
 
-		// Set에서 세션ID 제거
-		redisTemplate.opsForSet().remove(userKey, sessionId);
-		// 세션ID 제거
-		redisTemplate.delete("session-user:" + sessionId);
+        // Set에서 세션ID 제거
+        redisTemplate.opsForSet().remove(userKey, sessionId);
+        // 세션ID 제거
+        redisTemplate.delete("session-user:" + sessionId);
 
-		// 세션이 모두 제거되면 키 자체 제거
-		if (Boolean.TRUE.equals(redisTemplate.opsForSet().size(userKey) == 0)) {
-			redisTemplate.delete(userKey);
-		}
-	}
+        // 세션이 모두 제거되면 키 자체 제거
+        if (Boolean.TRUE.equals(redisTemplate.opsForSet().size(userKey) == 0)) {
+            redisTemplate.delete(userKey);
+        }
+    }
 
-	public boolean isUserConnected(Long userId) {
-		String userKey = USER_SESSION_KEY_PREFIX + userId;
-		// userKey가 Redis에 존재하는지 확인
-		return Boolean.TRUE.equals(redisTemplate.hasKey(userKey));
-	}
+    public boolean isUserConnected(Long userId) {
+        String userKey = USER_SESSION_KEY_PREFIX + userId;
+        // userKey가 Redis에 존재하는지 확인
+        return Boolean.TRUE.equals(redisTemplate.hasKey(userKey));
+    }
 
-	public Long getUserIdBySessionId(String sessionId) {
-		String sessionKey = "session-user:" + sessionId;
-		String userId = redisTemplate.opsForValue().get(sessionKey);
-		return userId != null ? Long.parseLong(userId) : null;
-	}
+    public Long getUserIdBySessionId(String sessionId) {
+        String sessionKey = "session-user:" + sessionId;
+        String userId = redisTemplate.opsForValue().get(sessionKey);
+        return userId != null ? Long.parseLong(userId) : null;
+    }
 
-	public Set<String> getSessionIds(Long userId) {
-		String userKey = USER_SESSION_KEY_PREFIX + userId;
-		return redisTemplate.opsForSet().members(userKey);
-	}
+    public Set<String> getSessionIds(Long userId) {
+        String userKey = USER_SESSION_KEY_PREFIX + userId;
+        return redisTemplate.opsForSet().members(userKey);
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
@@ -33,7 +33,7 @@ public class RedisUserSessionRegistry {
 		// userId별로 세션ID를 Set에 추가
 		redisTemplate.opsForSet().add(userKey, sessionId);
 		redisTemplate.expire(userKey, Duration.ofHours(6)); // 세션 만료 시간 설정
-		// Sting Key로 관리
+		// 단일 키 구조로 변경
 		String sessionKey = "session-user:" + sessionId;
 		redisTemplate.opsForValue().set(sessionKey, userId.toString(), Duration.ofHours(6));
 	}


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- Redis 세션 관리 방식 개선 및 sessionId 단위 TTL 적용
- 기존 SESSION_USER_KEY 해시 구조에서 session-user:{sessionId} 단일 키 구조로 변경
- sessionId → userId 매핑에 TTL 6시간 부여하여 비정상 종료 시 유령 세션 자동 정리
- getUserIdBySessionId, unregisterSession 등 관련 메서드 전체 수정
- 전체 WebSocket 세션 등록 흐름 성능 및 신뢰성 향상
- 메시지 조회 페이징 처리 사이즈 조절

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- #103 

## 💬 기타 코멘트
- x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
    - 다이렉트 메시지 목록 조회 시 한 페이지에 표시되는 메시지 개수가 100개에서 30개로 줄어듭니다.  
- **리팩터**
    - 세션과 사용자 매핑 방식이 간소화되어, 내부적으로 더 효율적으로 세션을 관리합니다. (사용자에게 직접적으로 보이는 변화는 없습니다.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->