### PR TITLE
[Feature] 유저 이미지 수정 및 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 }
 

--- a/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -11,6 +12,7 @@ import lombok.extern.log4j.Log4j2;
 import com.sparta.spartatigers.domain.user.dto.request.LoginRequestDto;
 import com.sparta.spartatigers.domain.user.dto.request.SignUpRequestDto;
 import com.sparta.spartatigers.domain.user.dto.response.AuthResponseDto;
+import com.sparta.spartatigers.domain.user.dto.response.ProfileResponseDto;
 import com.sparta.spartatigers.domain.user.dto.response.UserInfoResponseDto;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.service.UserService;
@@ -35,7 +37,8 @@ public class UserController {
     @GetMapping("/me")
     public ApiResponse<UserInfoResponseDto> getUserInfo(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        UserInfoResponseDto userInfoResponseDto = userService.getUserInfo(userPrincipal);
+        Long userId = userPrincipal.getUser().getId();
+        UserInfoResponseDto userInfoResponseDto = userService.getUserInfo(userId);
         return ApiResponse.ok(userInfoResponseDto);
     }
 
@@ -44,5 +47,28 @@ public class UserController {
     public ApiResponse<String> createUser(@RequestBody @Valid SignUpRequestDto signUpRequestDto) {
         userService.createUser(signUpRequestDto);
         return ApiResponse.ok(MessageCode.USER_REQUEST_SUCCESS.getMessage());
+    }
+
+    /*
+    유저 이미지 수정,
+    그리고 S3 내 이전 이미지 삭제
+     */
+    @PutMapping("/profile")
+    public ApiResponse<ProfileResponseDto> updateUserImage(
+            MultipartFile file, @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUser().getId();
+        return ApiResponse.ok(userService.updateProfile(file, userId));
+    }
+
+    /*
+    유저 이미지 삭제, 삭제 시 default 이미지로 변경된다.
+    그리고 S3 내 이전 이미지 삭제
+     */
+    @DeleteMapping("/profile")
+    public ApiResponse<String> deleteUserImage(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUser().getId();
+        userService.deleteProfile(userId);
+        return ApiResponse.ok("d");
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
@@ -55,7 +55,7 @@ public class UserController {
      */
     @PutMapping("/profile")
     public ApiResponse<ProfileResponseDto> updateUserImage(
-            MultipartFile file, @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+            @RequestParam("file") MultipartFile file, @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUser().getId();
         return ApiResponse.ok(userService.updateProfile(file, userId));
     }
@@ -69,6 +69,6 @@ public class UserController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUser().getId();
         userService.deleteProfile(userId);
-        return ApiResponse.ok("d");
+		return ApiResponse.ok(MessageCode.PROFILE_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
@@ -55,7 +55,8 @@ public class UserController {
      */
     @PutMapping("/profile")
     public ApiResponse<ProfileResponseDto> updateUserImage(
-            @RequestParam("file") MultipartFile file, @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUser().getId();
         return ApiResponse.ok(userService.updateProfile(file, userId));
     }
@@ -69,6 +70,6 @@ public class UserController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUser().getId();
         userService.deleteProfile(userId);
-		return ApiResponse.ok(MessageCode.PROFILE_DELETE_SUCCESS.getMessage());
+        return ApiResponse.ok(MessageCode.PROFILE_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/dto/response/ProfileResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/dto/response/ProfileResponseDto.java
@@ -1,0 +1,13 @@
+package com.sparta.spartatigers.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileResponseDto {
+    private String fileName;
+    private String filePath;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/dto/response/UserInfoResponseDto.java
@@ -11,7 +11,7 @@ public class UserInfoResponseDto {
     private final Long id;
     private final String email;
     private final String nickname;
-    private final String profilePath;
+    private final String path;
 
     public static UserInfoResponseDto from(User user) {
         return new UserInfoResponseDto(

--- a/src/main/java/com/sparta/spartatigers/domain/user/model/entity/User.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/model/entity/User.java
@@ -72,6 +72,11 @@ public class User extends BaseEntity implements Serializable {
         return new User(email, provider, providerId, nickname, path);
     }
 
+    // 이미지 수정
+    public void updatePath(String filePath) {
+        this.path = filePath;
+    }
+
     public void deleted() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/sparta/spartatigers/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/service/UserService.java
@@ -1,21 +1,33 @@
 package com.sparta.spartatigers.domain.user.service;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.user.dto.request.LoginRequestDto;
 import com.sparta.spartatigers.domain.user.dto.request.SignUpRequestDto;
 import com.sparta.spartatigers.domain.user.dto.response.AuthResponseDto;
+import com.sparta.spartatigers.domain.user.dto.response.ProfileResponseDto;
 import com.sparta.spartatigers.domain.user.dto.response.UserInfoResponseDto;
-import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
 import com.sparta.spartatigers.global.exception.ServerException;
+import com.sparta.spartatigers.global.util.FileUtil;
 import com.sparta.spartatigers.global.util.JwtUtil;
+import com.sparta.spartatigers.global.util.S3FolderType;
+import com.sparta.spartatigers.global.util.S3Properties;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -23,9 +35,16 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
+    private final FileUtil fileUtil;
 
-    public UserInfoResponseDto getUserInfo(CustomUserPrincipal userPrincipal) {
-        return UserInfoResponseDto.from(userPrincipal.getUser());
+    public UserInfoResponseDto getUserInfo(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new ServerException(ExceptionCode.USER_NOT_FOUND));
+        return UserInfoResponseDto.from(user);
     }
 
     @Transactional
@@ -55,5 +74,74 @@ public class UserService {
         }
         String token = jwtUtil.generateToken(loginRequestDto.getEmail(), "ROLE_USER");
         return AuthResponseDto.from(token);
+    }
+
+    @Transactional
+    public ProfileResponseDto updateProfile(MultipartFile file, Long userId) {
+        fileUtil.validateExtension(file);
+        fileUtil.validateFileSize(file);
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new ServerException(ExceptionCode.USER_NOT_FOUND));
+
+        String currentImagePath = user.getPath();
+        if (currentImagePath != null
+                && !currentImagePath.endsWith(s3Properties.getDefaultImagePath())) {
+            try {
+                String key = fileUtil.extractS3KeyFromUrl(currentImagePath);
+                amazonS3.deleteObject(s3Properties.getBucket(), key);
+            } catch (Exception e) {
+                throw new ServerException(ExceptionCode.FILE_DELETE_FAILED);
+            }
+        }
+
+        String folderPath = s3Properties.getFolderPath(S3FolderType.USER);
+        String originalFileName = file.getOriginalFilename();
+
+        String fileName = fileUtil.createFileName(folderPath, originalFileName);
+        String bucket = s3Properties.getBucket();
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata));
+        } catch (IOException e) {
+            throw new ServerException(ExceptionCode.FILE_UPLOAD_FAILED);
+        }
+
+        String filePath = amazonS3.getUrl(bucket, fileName).toString();
+
+        user.updatePath(filePath);
+        userRepository.save(user);
+
+        return new ProfileResponseDto(fileName, filePath);
+    }
+
+    @Transactional
+    public void deleteProfile(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new ServerException(ExceptionCode.USER_NOT_FOUND));
+
+        String currentImagePath = user.getPath();
+
+        if (currentImagePath.endsWith(s3Properties.getDefaultImagePath())) {
+            throw new InvalidRequestException(ExceptionCode.DEFAULT_IMAGE_CANNOT_BE_DELETED);
+        }
+        try {
+            String key = fileUtil.extractS3KeyFromUrl(currentImagePath);
+            amazonS3.deleteObject(s3Properties.getBucket(), key);
+        } catch (Exception e) {
+            throw new ServerException(ExceptionCode.FILE_DELETE_FAILED);
+        }
+        String defaultImageUrl =
+                amazonS3.getUrl(s3Properties.getBucket(), s3Properties.getDefaultImagePath())
+                        .toString();
+        user.updatePath(defaultImageUrl);
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/global/config/AwsS3Config.java
+++ b/src/main/java/com/sparta/spartatigers/global/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.sparta.spartatigers.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client)
+                AmazonS3ClientBuilder.standard()
+                        .withRegion(region)
+                        .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                        .build();
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/ExceptionCode.java
@@ -25,6 +25,16 @@ public enum ExceptionCode {
     NICKNAME_ALREADY_USED("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     ACCESS_DENIED("해당 계정의 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
+    // 파일
+    FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FILE_NOT_FOUND("파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_FILE_EXTENSION("허용되지 않은 파일 확장자입니다.", HttpStatus.BAD_REQUEST),
+    FILE_SIZE_EXCEEDED("파일 크기가 허용된 최대 크기를 초과했습니다.", HttpStatus.BAD_REQUEST),
+    FILE_DELETE_FAILED("파일 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_FILE_FORMAT("파일 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    FILE_ALREADY_EXISTS("이미 존재하는 파일입니다.", HttpStatus.CONFLICT),
+    DEFAULT_IMAGE_CANNOT_BE_DELETED("기본 이미지는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
     // 매치
     MATCH_NOT_FOUND("경기 일정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
@@ -11,7 +11,7 @@ public enum MessageCode {
 
     // 회원
     USER_REQUEST_SUCCESS("회원 요청을 성공적으로 보냈습니다."),
-	PROFILE_DELETE_SUCCESS("프로필이 성공적으로 삭제되었습니다."),
+    PROFILE_DELETE_SUCCESS("프로필이 성공적으로 삭제되었습니다."),
     // 라이브 보드
 
     // 알람

--- a/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
@@ -11,6 +11,7 @@ public enum MessageCode {
 
     // 회원
     USER_REQUEST_SUCCESS("회원 요청을 성공적으로 보냈습니다."),
+	PROFILE_DELETE_SUCCESS("프로필이 성공적으로 삭제되었습니다."),
     // 라이브 보드
 
     // 알람

--- a/src/main/java/com/sparta/spartatigers/global/util/FileUtil.java
+++ b/src/main/java/com/sparta/spartatigers/global/util/FileUtil.java
@@ -1,0 +1,56 @@
+package com.sparta.spartatigers.global.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
+
+@Component
+@RequiredArgsConstructor
+public class FileUtil {
+    private final S3Properties s3Properties;
+
+    public String createFileName(String folderPath, String originalFileName) {
+        String uuidSubstring = UUID.randomUUID().toString().substring(0, 5);
+        String safeOriginalName = originalFileName.replaceAll("\\s+", "_");
+        return folderPath + uuidSubstring + "_" + safeOriginalName;
+    }
+
+    public String extractS3KeyFromUrl(String url) {
+        try {
+            URL s3Url = new URL(url);
+            String rawPath = s3Url.getPath().substring(1); // /user/xxx.png → user/xxx.png
+            return URLDecoder.decode(rawPath, StandardCharsets.UTF_8);
+        } catch (MalformedURLException e) {
+            throw new ServerException(ExceptionCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    public void validateExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new ServerException(ExceptionCode.INVALID_FILE_FORMAT);
+        }
+
+        String ext =
+                originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        if (!s3Properties.getUpload().getAllowedExtensions().contains(ext)) {
+            throw new ServerException(ExceptionCode.INVALID_FILE_FORMAT);
+        }
+    }
+
+    public void validateFileSize(MultipartFile file) {
+        if (file.getSize() > s3Properties.getUpload().getMaxSize()) {
+            throw new ServerException(ExceptionCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/util/S3FolderType.java
+++ b/src/main/java/com/sparta/spartatigers/global/util/S3FolderType.java
@@ -1,0 +1,6 @@
+package com.sparta.spartatigers.global.util;
+
+public enum S3FolderType {
+    USER,
+    RECORD;
+}

--- a/src/main/java/com/sparta/spartatigers/global/util/S3Properties.java
+++ b/src/main/java/com/sparta/spartatigers/global/util/S3Properties.java
@@ -1,0 +1,45 @@
+package com.sparta.spartatigers.global.util;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+@Component
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+public class S3Properties {
+    private String bucket;
+    private Folders folders;
+    private Upload upload;
+    private String defaultImagePath;
+
+    @Getter
+    @Setter
+    public static class Folders {
+        private String user;
+        private String record;
+    }
+
+    @Getter
+    @Setter
+    public static class Upload {
+        private Long maxSize;
+        private List<String> allowedExtensions;
+    }
+
+    public String getFolderPath(S3FolderType type) {
+        return switch (type) {
+            case USER -> folders.getUser();
+            case RECORD -> folders.getRecord();
+        };
+    }
+}

--- a/src/main/resources/application-s3.yml
+++ b/src/main/resources/application-s3.yml
@@ -1,0 +1,24 @@
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3access_key}
+      secret-key: ${S3secret_key}
+    region:
+      static: ${S3region}
+    s3:
+      default-image-path: "default.png"
+      bucket: ${bucket_name}
+      folders:
+        user: user/
+        record: record/
+      upload:
+        max-size: 5242880 # 5MB
+        allowed-extensions:
+          - jpg
+          - jpeg
+          - png
+    stack:
+      auto: false
+
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
       - db.yml
       - redis.yml
       - application-social.yml
-
+      - application-s3.yml
   # ?? ??? ?? ????
   web.resources.add-mappings: false
 


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 유저 이미지 수정 및 삭제 등록의 경우는 처음 유저 생성 시 default 이미지 등록하였기에 메소드 구현 하지 않음
- S3 config 추가 및 파일 관련 설정 추가

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- 환경 변수 추가해야 제대로 동작

## 💬 기타 코멘트
- 이후 현재 브런치에서 직관 기록 파일 관련 푸시 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 프로필 이미지 업로드 및 삭제 기능이 추가되었습니다. 이제 사용자는 프로필 이미지를 변경하거나 기본 이미지로 되돌릴 수 있습니다.
- **설정**
  - AWS S3 연동이 추가되어 프로필 이미지가 안전하게 저장 및 관리됩니다.
  - S3 관련 환경설정 파일이 추가되고, 최대 파일 크기(5MB) 및 허용 확장자(jpg, jpeg, png)가 적용됩니다.
- **버그 수정**
  - 사용자 정보 응답에서 프로필 이미지 경로 필드명이 일관성 있게 변경되었습니다.
- **기타**
  - 파일 업로드/삭제 등 파일 관련 오류 코드가 추가되어 예외 상황에 대한 안내가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->