### PR TITLE
feat/direct message 채팅 기능 메시지 저장 로직 서비스로 분리 및 Redis 발행 구조 개선

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/ChatMessageController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/ChatMessageController.java
@@ -8,14 +8,14 @@ import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.chatroom.dto.request.ChatMessageRequest;
 import com.sparta.spartatigers.domain.chatroom.model.security.StompPrincipal;
-import com.sparta.spartatigers.domain.chatroom.pubsub.RedisDirectMessagePublisher;
+import com.sparta.spartatigers.domain.chatroom.service.ChatMessageService;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 
 @Controller
 @RequiredArgsConstructor
 public class ChatMessageController {
 
-    private final RedisDirectMessagePublisher redisPublisher;
+    private final ChatMessageService chatMessageService;
 
     /**
      * 클라이언트가 "/directRoom/send" 경로로 메시지를 보내면 호출 인증 정보를 기반으로 보낸 사용자의 ID를 추출 해당 메시지를 Redis 채널에 발행
@@ -37,6 +37,6 @@ public class ChatMessageController {
             throw new IllegalStateException("지원하지 않는 principal 타입: " + principalObj.getClass());
         }
 
-        redisPublisher.publish("directroom:" + request.getRoomId(), senderId, request);
+        chatMessageService.sendMessage(senderId, request);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/ChatMessageResponse.java
@@ -14,4 +14,13 @@ public class ChatMessageResponse {
     private String senderNickname;
     private String message;
     private LocalDateTime sentAt;
+
+    public static ChatMessageResponse from(RedisMessage message) {
+        return new ChatMessageResponse(
+                message.getRoomId(),
+                message.getSenderId(),
+                message.getSenderNickname(),
+                message.getMessage(),
+                LocalDateTime.parse(message.getSentAt()));
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/RedisMessage.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/RedisMessage.java
@@ -1,0 +1,30 @@
+package com.sparta.spartatigers.domain.chatroom.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.chatroom.model.entity.DirectMessage;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RedisMessage {
+
+    private Long senderId;
+    private Long roomId;
+    private String message;
+    private String
+            sentAt; // redis 발행할 때 json으로 변환 실패할 수도 있음(RedisDirectMessageSubscriber 역직렬화 할 때 실패할 수도
+    // 있어서 String 타입)
+    private String senderNickname;
+
+    public static RedisMessage from(DirectMessage message) {
+        return new RedisMessage(
+                message.getSender().getId(),
+                message.getDirectRoom().getId(),
+                message.getMessage(),
+                message.getSentAt().toString(),
+                message.getSender().getNickname());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/pubsub/RedisDirectMessagePublisher.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/pubsub/RedisDirectMessagePublisher.java
@@ -1,43 +1,28 @@
 package com.sparta.spartatigers.domain.chatroom.pubsub;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-import com.sparta.spartatigers.domain.chatroom.dto.request.ChatMessageRequest;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RedisDirectMessagePublisher {
 
     private final StringRedisTemplate redisStringTemplate;
     private final ObjectMapper objectMapper;
 
-    /**
-     * 주어진 senderId와 ChatMessageRequest의 내용으로 JSON 생성하고, 지정된 Redis 채널로 메시지를 발행합니다.
-     *
-     * @param topic Redis 채널 이름 (ex: "directroom:1")
-     * @param senderId 메시지를 보낸 사용자의 ID
-     * @param message 채팅 메시지 정보 (roomId, message 내용 포함)
-     */
-    public void publish(String topic, Long senderId, ChatMessageRequest message) {
+    /** 주어진 senderId와 ChatMessageRequest의 내용으로 JSON 생성하고, 지정된 Redis 채널로 메시지를 발행합니다. */
+    public void publish(String channel, Object messagePayload) {
         try {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("roomId", message.getRoomId());
-            payload.put("message", message.getMessage());
-            payload.put("senderId", senderId);
-
-            String json = objectMapper.writeValueAsString(payload);
-            redisStringTemplate.convertAndSend(topic, json);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            String json = objectMapper.writeValueAsString(messagePayload);
+            redisStringTemplate.convertAndSend(channel, json);
+        } catch (Exception e) {
+            log.error("Redis 발행 실패", e);
         }
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/pubsub/RedisDirectMessageSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/pubsub/RedisDirectMessageSubscriber.java
@@ -2,7 +2,6 @@ package com.sparta.spartatigers.domain.chatroom.pubsub;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.Map;
 
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -13,15 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import com.sparta.spartatigers.domain.chatroom.dto.response.ChatMessageResponse;
-import com.sparta.spartatigers.domain.chatroom.model.entity.DirectMessage;
-import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
-import com.sparta.spartatigers.domain.chatroom.registry.RedisUserSessionRegistry;
-import com.sparta.spartatigers.domain.chatroom.repository.DirectMessageRepository;
-import com.sparta.spartatigers.domain.chatroom.repository.DirectRoomRepository;
-import com.sparta.spartatigers.domain.user.model.entity.User;
-import com.sparta.spartatigers.domain.user.repository.UserRepository;
-import com.sparta.spartatigers.global.exception.ExceptionCode;
-import com.sparta.spartatigers.global.exception.InvalidRequestException;
+import com.sparta.spartatigers.domain.chatroom.dto.response.RedisMessage;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -31,66 +22,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class RedisDirectMessageSubscriber implements MessageListener {
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final DirectMessageRepository messageRepository;
-    private final UserRepository userRepository;
-    private final DirectRoomRepository roomRepository;
-    private final RedisUserSessionRegistry userSessionRegistry;
     private final ObjectMapper objectMapper;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            // Redis에서 전달된 메시지를 UTF-8 문자열로 변환
             String body = new String(message.getBody(), StandardCharsets.UTF_8);
-            Map<String, Object> payload = objectMapper.readValue(body, Map.class);
-
-            Long senderId = Long.parseLong(payload.get("senderId").toString());
-            Long roomId = Long.parseLong(payload.get("roomId").toString());
-            String messageText = payload.get("message").toString();
-
-            DirectRoom room =
-                    roomRepository
-                            .findById(roomId)
-                            .orElseThrow(
-                                    () ->
-                                            new InvalidRequestException(
-                                                    ExceptionCode.CHATROOM_NOT_FOUND));
-            User sender =
-                    userRepository
-                            .findById(senderId)
-                            .orElseThrow(
-                                    () ->
-                                            new InvalidRequestException(
-                                                    ExceptionCode.USER_NOT_FOUND));
-
-            // 수신자 결정 (sender와 반대편 유저)
-            User receiver =
-                    room.getSender().getId().equals(senderId)
-                            ? room.getReceiver()
-                            : room.getSender();
-            Long receiverId = receiver.getId();
-
-            boolean isConnectedHere = userSessionRegistry.isUserConnected(receiverId);
-
-            if (!isConnectedHere) {
-                log.info("Receiver {} is not connected here. Skipping.", receiverId);
-                return;
-            }
-
-            DirectMessage savedMessage =
-                    messageRepository.save(
-                            new DirectMessage(room, sender, messageText, LocalDateTime.now()));
+            RedisMessage payload = objectMapper.readValue(body, RedisMessage.class);
 
             ChatMessageResponse response =
                     new ChatMessageResponse(
-                            roomId,
-                            senderId,
-                            sender.getNickname(),
-                            messageText,
-                            savedMessage.getSentAt());
+                            payload.getRoomId(),
+                            payload.getSenderId(),
+                            payload.getSenderNickname(),
+                            payload.getMessage(),
+                            LocalDateTime.parse(payload.getSentAt()));
 
-            messagingTemplate.convertAndSend("/server/directRoom/" + roomId, response);
-            log.info("Redis 메시지 수신 처리 완료");
+            messagingTemplate.convertAndSend("/server/directRoom/" + payload.getRoomId(), response);
+            log.info("Redis 메시지 WebSocket 전송 완료");
 
         } catch (Exception e) {
             log.error("RedisDirectMessageSubscriber 오류 발생", e);

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/pubsub/RedisDirectMessageSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/pubsub/RedisDirectMessageSubscriber.java
@@ -1,7 +1,6 @@
 package com.sparta.spartatigers.domain.chatroom.pubsub;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -30,16 +29,10 @@ public class RedisDirectMessageSubscriber implements MessageListener {
             String body = new String(message.getBody(), StandardCharsets.UTF_8);
             RedisMessage payload = objectMapper.readValue(body, RedisMessage.class);
 
-            ChatMessageResponse response =
-                    new ChatMessageResponse(
-                            payload.getRoomId(),
-                            payload.getSenderId(),
-                            payload.getSenderNickname(),
-                            payload.getMessage(),
-                            LocalDateTime.parse(payload.getSentAt()));
+            ChatMessageResponse response = ChatMessageResponse.from(payload);
 
             messagingTemplate.convertAndSend("/server/directRoom/" + payload.getRoomId(), response);
-            log.info("Redis 메시지 WebSocket 전송 완료");
+            log.info("Redis 메시지 수신 처리 완료");
 
         } catch (Exception e) {
             log.error("RedisDirectMessageSubscriber 오류 발생", e);

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/registry/RedisUserSessionRegistry.java
@@ -12,9 +12,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RedisUserSessionRegistry {
 
+    // TODO: 세션-userId를 redis에서 관리하는 구조를 유지해야 할 이유를 찾기
     private static final String USER_SESSION_KEY_PREFIX =
             "user-sessions:"; // userId -> Set<sessionId>
-    private static final String SESSION_USER_KEY = "session-users"; // sessionId -> userId
     private final StringRedisTemplate redisTemplate;
 
     // 멀티 세션 불가 x (메시지 중복 수신 문제 발생)

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/service/ChatMessageService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/service/ChatMessageService.java
@@ -1,0 +1,58 @@
+package com.sparta.spartatigers.domain.chatroom.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.domain.chatroom.dto.request.ChatMessageRequest;
+import com.sparta.spartatigers.domain.chatroom.dto.response.RedisMessage;
+import com.sparta.spartatigers.domain.chatroom.model.entity.DirectMessage;
+import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
+import com.sparta.spartatigers.domain.chatroom.pubsub.RedisDirectMessagePublisher;
+import com.sparta.spartatigers.domain.chatroom.repository.DirectMessageRepository;
+import com.sparta.spartatigers.domain.chatroom.repository.DirectRoomRepository;
+import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.domain.user.repository.UserRepository;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final DirectRoomRepository directRoomRepository;
+    private final UserRepository userRepository;
+    private final DirectMessageRepository directMessageRepository;
+    private final RedisDirectMessagePublisher redisPublisher;
+
+    @Transactional
+    public void sendMessage(Long senderId, ChatMessageRequest request) {
+        Long roomId = request.getRoomId();
+        String messageText = request.getMessage();
+
+        DirectRoom room =
+                directRoomRepository
+                        .findById(roomId)
+                        .orElseThrow(
+                                () ->
+                                        new InvalidRequestException(
+                                                ExceptionCode.CHATROOM_NOT_FOUND));
+
+        User sender =
+                userRepository
+                        .findById(senderId)
+                        .orElseThrow(
+                                () -> new InvalidRequestException(ExceptionCode.USER_NOT_FOUND));
+
+        // db에 메시지 저장
+        DirectMessage savedMessage =
+                directMessageRepository.save(
+                        new DirectMessage(room, sender, messageText, LocalDateTime.now()));
+
+        // redis 발행
+        redisPublisher.publish("directRoom:" + roomId, RedisMessage.from(savedMessage));
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/config/RedisDirectRoomMessageSubscriberConfig.java
+++ b/src/main/java/com/sparta/spartatigers/global/config/RedisDirectRoomMessageSubscriberConfig.java
@@ -24,9 +24,9 @@ public class RedisDirectRoomMessageSubscriberConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
 
-        // 모든 directroom:{id} 형식의 채널 구독
-        container.addMessageListener(subscriber, new PatternTopic("directroom:*"));
-        log.info("연결된 채팅방: directroom:*");
+        // 모든 directRoom:{id} 형식의 채널 구독
+        container.addMessageListener(subscriber, new PatternTopic("directRoom:*"));
+        log.info("연결된 채팅방: directRoom:*");
 
         return container;
     }


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- sendMessage 로직을 ChatMessageService로 분리
- DirectMessage 저장 후 RedisMessage DTO로 변환해 Redis 발행
- Redis 발행 시 DTO에서 LocalDateTime을 문자열 포맷 처리
- WebSocket 인증 시 RedisUserSessionRegistry 의존 제거
- Config 주소 살짝 수정 directroom -> directRoom

## ✅ 체크리스트
- [x] 테스트 완료
- [x] 코드 리뷰 반영
- [x] 관련 문서 수정

## 🔗 관련 이슈
- #107 

## 💬 기타 코멘트
- x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 채팅 메시지 전송을 위한 서비스 레이어가 도입되어 메시지 처리 방식이 개선되었습니다.
    - Redis 메시지 포맷을 위한 새로운 데이터 객체가 추가되었습니다.

- **버그 수정**
    - Redis 채널 구독 패턴이 "directRoom:*"으로 수정되어 메시지 송수신의 일관성이 향상되었습니다.

- **리팩터링**
    - 메시지 발송 및 구독 로직이 단순화되어 코드 유지보수성이 높아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->