### PR TITLE
[feat/item] 티켓 & 굿즈 성능 최적화 및 이미지 등록

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
@@ -1,18 +1,18 @@
 package com.sparta.spartatigers.domain.item.controller;
 
-import jakarta.validation.Valid;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,12 +31,13 @@ public class ItemController {
 
     private final ItemService itemService;
 
-    @PostMapping
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ApiResponse<CreateItemResponseDto> createItem(
-            @Valid @RequestBody CreateItemWithLocationRequestDto request,
+            @RequestPart("request") CreateItemWithLocationRequestDto request,
+            @RequestPart(value = "file", required = false) MultipartFile file,
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
 
-        CreateItemResponseDto response = itemService.createItem(request, userPrincipal);
+        CreateItemResponseDto response = itemService.createItem(request, file, userPrincipal);
 
         return ApiResponse.created(response);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/request/CreateItemRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/request/CreateItemRequestDto.java
@@ -7,7 +7,6 @@ import com.sparta.spartatigers.domain.item.model.entity.Item.Category;
 
 public record CreateItemRequestDto(
         @NotNull(message = "카테고리는 필수입니다.") Category category,
-        String image,
         @NotBlank(message = "제목은 필수입니다.") String title,
         String seatInfo,
         String description) {}

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemFlatResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemFlatResponseDto.java
@@ -1,0 +1,36 @@
+package com.sparta.spartatigers.domain.item.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.sparta.spartatigers.domain.item.model.entity.Item.Category;
+import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ReadItemFlatResponseDto(
+        Long id,
+        Long userId,
+        String nickname,
+        Category category,
+        String title,
+        Status status,
+        LocalDateTime createdAt) {
+
+    @QueryProjection
+    public ReadItemFlatResponseDto(
+            Long id,
+            Long userId,
+            String nickname,
+            Category category,
+            String title,
+            Status status,
+            LocalDateTime createdAt) {
+        this.id = id;
+        this.userId = userId;
+        this.nickname = nickname;
+        this.category = category;
+        this.title = title;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemResponseDto.java
@@ -25,4 +25,14 @@ public record ReadItemResponseDto(
                 item.getStatus(),
                 item.getCreatedAt());
     }
+
+    public static ReadItemResponseDto from(ReadItemFlatResponseDto dto) {
+        return new ReadItemResponseDto(
+                dto.id(),
+                UserResponseDto.from(dto.userId(), dto.nickname()),
+                dto.category(),
+                dto.title(),
+                dto.status(),
+                dto.createdAt());
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/model/entity/Item.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/model/entity/Item.java
@@ -87,10 +87,10 @@ public class Item extends BaseEntity {
         this.createdDate = createdDate;
     }
 
-    public static Item of(CreateItemRequestDto dto, User user) {
+    public static Item of(CreateItemRequestDto dto, User user, String image) {
         return new Item(
                 dto.category(),
-                dto.image(),
+                image,
                 dto.seatInfo(),
                 dto.title(),
                 dto.description(),

--- a/src/main/java/com/sparta/spartatigers/domain/item/model/entity/Item.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/model/entity/Item.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -35,6 +36,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
             @UniqueConstraint(
                     name = "UNIQUE_USER_ITEM",
                     columnNames = {"user_id", "created_date"})
+        },
+        indexes = {
+            @Index(
+                    name = "idx_item_user_status_created",
+                    columnList = "user_id, status, createdAt DESC"),
+            @Index(name = "idx_item_status_created_date", columnList = "status, createdDate")
         })
 public class Item extends BaseEntity {
 

--- a/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemQueryRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemQueryRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.sparta.spartatigers.domain.item.dto.response.ReadItemFlatResponseDto;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
 import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
 import com.sparta.spartatigers.global.exception.ExceptionCode;
@@ -14,7 +15,8 @@ import com.sparta.spartatigers.global.exception.ServerException;
 
 public interface ItemQueryRepository {
 
-    Page<Item> findAllByStatus(Status status, List<Long> nearByUserIds, Pageable pageable);
+    Page<ReadItemFlatResponseDto> findAllByStatus(
+            Status status, List<Long> nearByUserIds, Pageable pageable);
 
     Optional<Item> findItemById(Long itemId, Status status);
 

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.item.dto.request.CreateItemWithLocationRequestDto;
+import com.sparta.spartatigers.domain.item.dto.request.LocationRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.CreateItemResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemFlatResponseDto;
@@ -20,6 +21,8 @@ import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
 import com.sparta.spartatigers.domain.item.repository.ItemRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
 import com.sparta.spartatigers.global.service.S3Service;
 import com.sparta.spartatigers.global.util.S3FolderType;
 
@@ -38,14 +41,14 @@ public class ItemService {
             MultipartFile file,
             CustomUserPrincipal principal) {
 
-        //		LocationRequestDto locationDto = request.getLocationDto();
-        //		boolean isNear =
-        //			locationService.isNearStadium(
-        //				locationDto.getLongitude(), locationDto.getLatitude());
-        //
-        //		if (!isNear) {
-        //			throw new ServerException(ExceptionCode.LOCATION_NOT_VALID);
-        //		}
+        LocationRequestDto locationDto = request.getLocationDto();
+        boolean isNear =
+                locationService.isNearStadium(
+                        locationDto.getLongitude(), locationDto.getLatitude());
+
+        if (!isNear) {
+            throw new ServerException(ExceptionCode.LOCATION_NOT_VALID);
+        }
 
         String image = s3Service.uploadFile(file, S3FolderType.ITEM);
 

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -13,6 +13,7 @@ import com.sparta.spartatigers.domain.item.dto.request.CreateItemWithLocationReq
 import com.sparta.spartatigers.domain.item.dto.request.LocationRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.CreateItemResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
+import com.sparta.spartatigers.domain.item.dto.response.ReadItemFlatResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemResponseDto;
 import com.sparta.spartatigers.domain.item.model.entity.Item;
 import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
@@ -63,7 +64,7 @@ public class ItemService {
         List<Long> nearByUserIds = locationService.findUsersNearBy(userId, SEARCH_RADIUS_KM);
         nearByUserIds.add(userId);
 
-        Page<Item> itemList =
+        Page<ReadItemFlatResponseDto> itemList =
                 itemRepository.findAllByStatus(Status.REGISTERED, nearByUserIds, pageable);
 
         return itemList.map(ReadItemResponseDto::from);

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -6,11 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.item.dto.request.CreateItemWithLocationRequestDto;
-import com.sparta.spartatigers.domain.item.dto.request.LocationRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.CreateItemResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemFlatResponseDto;
@@ -20,8 +20,8 @@ import com.sparta.spartatigers.domain.item.model.entity.Item.Status;
 import com.sparta.spartatigers.domain.item.repository.ItemRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
-import com.sparta.spartatigers.global.exception.ExceptionCode;
-import com.sparta.spartatigers.global.exception.ServerException;
+import com.sparta.spartatigers.global.service.S3Service;
+import com.sparta.spartatigers.global.util.S3FolderType;
 
 @Service
 @RequiredArgsConstructor
@@ -30,23 +30,28 @@ public class ItemService {
     private static final double SEARCH_RADIUS_KM = 0.05;
     private final ItemRepository itemRepository;
     private final LocationService locationService;
+    private final S3Service s3Service;
 
     @Transactional
     public CreateItemResponseDto createItem(
-            CreateItemWithLocationRequestDto request, CustomUserPrincipal principal) {
+            CreateItemWithLocationRequestDto request,
+            MultipartFile file,
+            CustomUserPrincipal principal) {
 
-        LocationRequestDto locationDto = request.getLocationDto();
-        boolean isNear =
-                locationService.isNearStadium(
-                        locationDto.getLongitude(), locationDto.getLatitude());
+        //		LocationRequestDto locationDto = request.getLocationDto();
+        //		boolean isNear =
+        //			locationService.isNearStadium(
+        //				locationDto.getLongitude(), locationDto.getLatitude());
+        //
+        //		if (!isNear) {
+        //			throw new ServerException(ExceptionCode.LOCATION_NOT_VALID);
+        //		}
 
-        if (!isNear) {
-            throw new ServerException(ExceptionCode.LOCATION_NOT_VALID);
-        }
+        String image = s3Service.uploadFile(file, S3FolderType.ITEM);
 
         User user = principal.getUser();
 
-        Item item = Item.of(request.getItemDto(), user);
+        Item item = Item.of(request.getItemDto(), user, image);
         itemRepository.save(item);
 
         ReadItemResponseDto newItemDto = ReadItemResponseDto.from(item);

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/LocationService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/LocationService.java
@@ -1,5 +1,6 @@
 package com.sparta.spartatigers.domain.item.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -68,7 +69,7 @@ public class LocationService {
         Point userPoint = redisTemplate.opsForGeo().position(USER_LOCATION_KEY, userId).get(0);
 
         if (userPoint == null) {
-            return List.of();
+            return new ArrayList<>();
         }
         Distance distance = new Distance(radius, Metrics.KILOMETERS);
         Circle circle = new Circle(userPoint, distance);
@@ -76,7 +77,7 @@ public class LocationService {
                 redisTemplate.opsForGeo().radius(USER_LOCATION_KEY, circle);
 
         if (results == null) {
-            return List.of();
+            return new ArrayList<>();
         }
         return results.getContent().stream()
                 .map(result -> Long.valueOf(result.getContent().getName().toString()))

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/LocationService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/LocationService.java
@@ -43,9 +43,11 @@ public class LocationService {
 
     @PostConstruct
     public void loadStadiumLocation() {
-        List<Stadium> stadiums = stadiumRepository.findAll();
 
-        redisTemplate.delete(STADIUM_LOCATION_KEY);
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(STADIUM_LOCATION_KEY))) {
+            return;
+        }
+        List<Stadium> stadiums = stadiumRepository.findAll();
 
         for (Stadium stadium : stadiums) {
             Point point = new Point(stadium.getLongitude(), stadium.getLatitude());

--- a/src/main/java/com/sparta/spartatigers/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/dto/response/UserResponseDto.java
@@ -7,4 +7,8 @@ public record UserResponseDto(Long userId, String userNickname) {
     public static UserResponseDto from(User user) {
         return new UserResponseDto(user.getId(), user.getNickname());
     }
+
+    public static UserResponseDto from(Long userId, String userNickname) {
+        return new UserResponseDto(userId, userNickname);
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/global/service/S3Service.java
+++ b/src/main/java/com/sparta/spartatigers/global/service/S3Service.java
@@ -1,0 +1,53 @@
+package com.sparta.spartatigers.global.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
+import com.sparta.spartatigers.global.util.FileUtil;
+import com.sparta.spartatigers.global.util.S3FolderType;
+import com.sparta.spartatigers.global.util.S3Properties;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
+    private final FileUtil fileUtil;
+
+    public String uploadFile(MultipartFile file, S3FolderType folderType) {
+        if (file == null || file.isEmpty()) {
+            return s3Properties.getDefaultImagePath();
+        }
+        fileUtil.validateExtension(file);
+        fileUtil.validateFileSize(file);
+
+        String folderPath = s3Properties.getFolderPath(folderType);
+        String originalFileName = file.getOriginalFilename();
+        String fileName = fileUtil.createFileName(folderPath, originalFileName);
+        String bucket = s3Properties.getBucket();
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata));
+        } catch (IOException e) {
+            throw new ServerException(ExceptionCode.FILE_UPLOAD_FAILED);
+        }
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/util/S3FolderType.java
+++ b/src/main/java/com/sparta/spartatigers/global/util/S3FolderType.java
@@ -2,5 +2,6 @@ package com.sparta.spartatigers.global.util;
 
 public enum S3FolderType {
     USER,
-    RECORD;
+    RECORD,
+    ITEM
 }

--- a/src/main/java/com/sparta/spartatigers/global/util/S3Properties.java
+++ b/src/main/java/com/sparta/spartatigers/global/util/S3Properties.java
@@ -17,29 +17,34 @@ import lombok.Setter;
 @NoArgsConstructor
 @Setter
 public class S3Properties {
+
     private String bucket;
     private Folders folders;
     private Upload upload;
     private String defaultImagePath;
 
+    public String getFolderPath(S3FolderType type) {
+        return switch (type) {
+            case USER -> folders.getUser();
+            case RECORD -> folders.getRecord();
+            case ITEM -> folders.getItem();
+        };
+    }
+
     @Getter
     @Setter
     public static class Folders {
+
         private String user;
         private String record;
+        private String item;
     }
 
     @Getter
     @Setter
     public static class Upload {
+
         private Long maxSize;
         private List<String> allowedExtensions;
-    }
-
-    public String getFolderPath(S3FolderType type) {
-        return switch (type) {
-            case USER -> folders.getUser();
-            case RECORD -> folders.getRecord();
-        };
     }
 }


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- findUsersNearBy 메소드의 반환 타입을 가변 리스트로 변경
- 티켓 & 굿즈 목록 조회 성능 최적화
  - 인덱스 적용
  - dto projection 적용
- Redis TTL 적용
- Redis에 stadium 위치 정보가 이미 존재할 경우 중복 저장되지 않도록 조건문 추가
- 티켓 & 굿즈 등록 시 이미지가 s3에 저장되도록 구현
  - global에 S3Service 추가

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- close #110 
- close #114 

## 💬 기타 코멘트
- 
