### PR TITLE
feat/direct message 채팅방 목록 조회 시 상대방 접속 여부 로직 추가 및 응답 데이터 추가

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/chat-tester.html
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/chat-tester.html
@@ -21,6 +21,8 @@
   <br/><br/>
   <button onclick="connect()">연결하기</button>
   <button onclick="sendMessage()">메시지 보내기</button>
+  <button onclick="disconnect()">연결 해제</button>
+
 </div>
 
 <hr/>
@@ -89,6 +91,19 @@
         })
     );
   }
+
+  function disconnect() {
+    if (stompClient && stompClient.connected) {
+      stompClient.disconnect(function () {
+        console.log("Disconnected");
+        alert("연결이 해제되었습니다.");
+      });
+    } else {
+      alert("연결되어 있지 않습니다.");
+    }
+  }
+
+
 </script>
 </body>
 </html>

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectRoomController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/DirectRoomController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.sparta.spartatigers.domain.chatroom.dto.request.CreateDirectRoomRequestDto;
+import com.sparta.spartatigers.domain.chatroom.dto.response.DirectRoomCreateResponseDto;
 import com.sparta.spartatigers.domain.chatroom.dto.response.DirectRoomResponseDto;
 import com.sparta.spartatigers.domain.chatroom.service.DirectRoomService;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
@@ -31,11 +32,11 @@ public class DirectRoomController {
     private final DirectRoomService directRoomService;
 
     @PostMapping
-    public ApiResponse<DirectRoomResponseDto> createDirectRoom(
+    public ApiResponse<DirectRoomCreateResponseDto> createDirectRoom(
             @Valid @RequestBody CreateDirectRoomRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUser().getId();
-        DirectRoomResponseDto directRoomDto =
+        DirectRoomCreateResponseDto directRoomDto =
                 directRoomService.createRoom(request.getExchangeRequestId(), userId);
         return ApiResponse.created(directRoomDto);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/UserConnectController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/UserConnectController.java
@@ -22,10 +22,11 @@ public class UserConnectController {
     @GetMapping("/{userId}")
     public ApiResponse<Map<String, Object>> userOnlineOrOffline(@PathVariable Long userId) {
         boolean online = userConnectService.isUserOnline(userId);
+        // TODO: 인증, 인가
         Map<String, Object> response =
                 Map.of(
                         "userId", userId,
-                        "접속여부", online);
+                        "isConnected", online);
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/UserConnectController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/controller/UserConnectController.java
@@ -1,0 +1,31 @@
+package com.sparta.spartatigers.domain.chatroom.controller;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.domain.chatroom.service.UserConnectService;
+import com.sparta.spartatigers.global.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/direct-rooms/user-connect")
+public class UserConnectController {
+
+    private final UserConnectService userConnectService;
+
+    @GetMapping("/{userId}")
+    public ApiResponse<Map<String, Object>> userOnlineOrOffline(@PathVariable Long userId) {
+        boolean online = userConnectService.isUserOnline(userId);
+        Map<String, Object> response =
+                Map.of(
+                        "userId", userId,
+                        "접속여부", online);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomCreateResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomCreateResponseDto.java
@@ -11,7 +11,7 @@ import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class DirectRoomResponseDto {
+public class DirectRoomCreateResponseDto {
 
     private Long directRoomId;
     private Long exchangeRequestId;
@@ -21,10 +21,9 @@ public class DirectRoomResponseDto {
     private boolean isCompleted;
     private LocalDateTime completedAt;
     private LocalDateTime createdAt;
-    private boolean isReceiverOnline;
 
-    public static DirectRoomResponseDto from(DirectRoom room, boolean isReceiverOnline) {
-        return new DirectRoomResponseDto(
+    public static DirectRoomCreateResponseDto from(DirectRoom room) {
+        return new DirectRoomCreateResponseDto(
                 room.getId(),
                 room.getExchangeRequest().getId(),
                 room.getSender().getId(),
@@ -32,7 +31,6 @@ public class DirectRoomResponseDto {
                 room.getReceiver().getNickname(),
                 room.isCompleted(),
                 room.getCompletedAt(),
-                room.getCreatedAt(),
-                isReceiverOnline);
+                room.getCreatedAt());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomCreateResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomCreateResponseDto.java
@@ -1,36 +1,32 @@
 package com.sparta.spartatigers.domain.chatroom.dto.response;
 
+import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
 import java.time.LocalDateTime;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class DirectRoomCreateResponseDto {
 
-    private Long directRoomId;
-    private Long exchangeRequestId;
-    private Long senderId;
-    private Long receiverId;
-    private String receiverNickname;
-    private boolean isCompleted;
-    private LocalDateTime completedAt;
-    private LocalDateTime createdAt;
+	private Long directRoomId;
+	private Long exchangeRequestId;
+	private Long senderId;
+	private Long receiverId;
+	private boolean isCompleted;
+	private LocalDateTime completedAt;
+	private LocalDateTime createdAt;
 
-    public static DirectRoomCreateResponseDto from(DirectRoom room) {
-        return new DirectRoomCreateResponseDto(
-                room.getId(),
-                room.getExchangeRequest().getId(),
-                room.getSender().getId(),
-                room.getReceiver().getId(),
-                room.getReceiver().getNickname(),
-                room.isCompleted(),
-                room.getCompletedAt(),
-                room.getCreatedAt());
-    }
+	public static DirectRoomCreateResponseDto from(DirectRoom room) {
+		return new DirectRoomCreateResponseDto(
+			room.getId(),
+			room.getExchangeRequest().getId(),
+			room.getSender().getId(),
+			room.getReceiver().getId(),
+			room.isCompleted(),
+			room.getCompletedAt(),
+			room.getCreatedAt());
+	}
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomCreateResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomCreateResponseDto.java
@@ -1,32 +1,34 @@
 package com.sparta.spartatigers.domain.chatroom.dto.response;
 
-import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
 import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class DirectRoomCreateResponseDto {
 
-	private Long directRoomId;
-	private Long exchangeRequestId;
-	private Long senderId;
-	private Long receiverId;
-	private boolean isCompleted;
-	private LocalDateTime completedAt;
-	private LocalDateTime createdAt;
+    private Long directRoomId;
+    private Long exchangeRequestId;
+    private Long senderId;
+    private Long receiverId;
+    private boolean isCompleted;
+    private LocalDateTime completedAt;
+    private LocalDateTime createdAt;
 
-	public static DirectRoomCreateResponseDto from(DirectRoom room) {
-		return new DirectRoomCreateResponseDto(
-			room.getId(),
-			room.getExchangeRequest().getId(),
-			room.getSender().getId(),
-			room.getReceiver().getId(),
-			room.isCompleted(),
-			room.getCompletedAt(),
-			room.getCreatedAt());
-	}
+    public static DirectRoomCreateResponseDto from(DirectRoom room) {
+        return new DirectRoomCreateResponseDto(
+                room.getId(),
+                room.getExchangeRequest().getId(),
+                room.getSender().getId(),
+                room.getReceiver().getId(),
+                room.isCompleted(),
+                room.getCompletedAt(),
+                room.getCreatedAt());
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomResponseDto.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.spartatigers.domain.chatroom.model.entity.DirectRoom;
+import com.sparta.spartatigers.domain.exchangerequest.model.entity.ExchangeRequest;
+import com.sparta.spartatigers.domain.item.model.entity.Item;
+import com.sparta.spartatigers.domain.user.model.entity.User;
 
 @Getter
 @AllArgsConstructor
@@ -17,22 +20,37 @@ public class DirectRoomResponseDto {
     private Long exchangeRequestId;
     private Long senderId;
     private Long receiverId;
-    private String receiverNickname;
-    private boolean isCompleted;
     private LocalDateTime completedAt;
     private LocalDateTime createdAt;
-    private boolean receiverOnline;
+    private boolean isCompleted;
+    private String itemTitle;
+    private String itemCategory;
+    private String itemImage;
+    private String opponentNickname;
+    private String opponentImage;
+    private boolean opponentOnline;
 
-    public static DirectRoomResponseDto from(DirectRoom room, boolean receiverOnline) {
+    public static DirectRoomResponseDto from(
+            DirectRoom room, Long currentUserId, boolean opponentOnline) {
+        ExchangeRequest exchangeRequest = room.getExchangeRequest();
+        Item item = exchangeRequest.getItem();
+
+        boolean isSender = room.getSender().getId().equals(currentUserId);
+        User opponent = isSender ? room.getReceiver() : room.getSender();
+
         return new DirectRoomResponseDto(
                 room.getId(),
-                room.getExchangeRequest().getId(),
+                exchangeRequest.getId(),
                 room.getSender().getId(),
                 room.getReceiver().getId(),
-                room.getReceiver().getNickname(),
-                room.isCompleted(),
                 room.getCompletedAt(),
                 room.getCreatedAt(),
-                receiverOnline);
+                room.isCompleted(),
+                item.getTitle(),
+                item.getCategory().name(),
+                item.getImage(),
+                opponent.getNickname(),
+                opponent.getPath(),
+                opponentOnline);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/dto/response/DirectRoomResponseDto.java
@@ -21,9 +21,9 @@ public class DirectRoomResponseDto {
     private boolean isCompleted;
     private LocalDateTime completedAt;
     private LocalDateTime createdAt;
-    private boolean isReceiverOnline;
+    private boolean receiverOnline;
 
-    public static DirectRoomResponseDto from(DirectRoom room, boolean isReceiverOnline) {
+    public static DirectRoomResponseDto from(DirectRoom room, boolean receiverOnline) {
         return new DirectRoomResponseDto(
                 room.getId(),
                 room.getExchangeRequest().getId(),
@@ -33,6 +33,6 @@ public class DirectRoomResponseDto {
                 room.isCompleted(),
                 room.getCompletedAt(),
                 room.getCreatedAt(),
-                isReceiverOnline);
+                receiverOnline);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/repository/DirectRoomRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/repository/DirectRoomRepository.java
@@ -19,11 +19,13 @@ public interface DirectRoomRepository extends JpaRepository<DirectRoom, Long> {
                     "select dr from direct_rooms dr "
                             + "join fetch dr.sender s "
                             + "join fetch dr.receiver r "
+                            + "join fetch dr.exchangeRequest er "
+                            + "join fetch er.item i "
                             + "where dr.sender.id = :userId or dr.receiver.id = :userId",
             countQuery =
                     "select count(dr) from direct_rooms dr "
                             + "where dr.sender.id = :userId or dr.receiver.id = :userId")
-    Page<DirectRoom> findBySenderIdOrReceiverIdWithUsers(Long userId, Pageable pageable);
+    Page<DirectRoom> findBySenderIdOrReceiverIdWithUsersAndItem(Long userId, Pageable pageable);
 
     Optional<DirectRoom> findByExchangeRequestId(Long exchangeRequestId);
 }

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/service/DirectRoomService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/service/DirectRoomService.java
@@ -56,19 +56,18 @@ public class DirectRoomService {
 
     public Page<DirectRoomResponseDto> getRoomsForUser(Long currentUserId, Pageable pageable) {
         return directRoomRepository
-                .findBySenderIdOrReceiverIdWithUsers(currentUserId, pageable)
+                .findBySenderIdOrReceiverIdWithUsersAndItem(currentUserId, pageable)
                 .map(
                         room -> {
-                            // 만약 현재 로그인한 유저가 sender면 receiver를 아니면 그 반대 유저 id를 가져오는 로직(상대방 유저를 찾는
-                            // 로직)
-                            Long receiverId =
+                            // 현재 로그인한 유저의 상대방 id 가져옴
+                            Long opponentId =
                                     room.getSender().getId().equals(currentUserId)
                                             ? room.getReceiver().getId()
                                             : room.getSender().getId();
 
-                            boolean isOnline = userConnectService.isUserOnline(receiverId);
+                            boolean isOnline = userConnectService.isUserOnline(opponentId);
 
-                            return DirectRoomResponseDto.from(room, isOnline);
+                            return DirectRoomResponseDto.from(room, currentUserId, isOnline);
                         });
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/service/UserConnectService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/service/UserConnectService.java
@@ -1,0 +1,18 @@
+package com.sparta.spartatigers.domain.chatroom.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.spartatigers.domain.chatroom.registry.RedisUserSessionRegistry;
+
+@Service
+@RequiredArgsConstructor
+public class UserConnectService {
+
+    private final RedisUserSessionRegistry userSessionRegistry;
+
+    public boolean isUserOnline(Long userId) {
+        return userSessionRegistry.isUserConnected(userId);
+    }
+}


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 채팅방 목록 조회 시 상대방 유저 접속 여부 상태 확인 로직 추가
- 특정 유저 접속 여부 api 추가
- 채팅방 목록 조회 시 응답 데이터 추가

## ✅ 체크리스트
- [x] 테스트 완료
- [x] 코드 리뷰 반영
- [x] 관련 문서 수정

## 🔗 관련 이슈
- #122 

## 💬 기타 코멘트
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채팅 테스터 UI에 WebSocket 연결을 명시적으로 종료할 수 있는 "연결 해제" 버튼이 추가되었습니다.
  * 사용자의 온라인 상태를 확인할 수 있는 REST API 엔드포인트가 추가되었습니다.
  * 채팅방 생성 시 응답 데이터가 확장되어 더 많은 정보를 제공합니다.
  * 사용자 연결 상태를 관리하는 서비스가 도입되었습니다.

* **기능 개선**
  * 채팅방 목록 조회 시 상대방의 온라인 상태, 아이템 정보, 상대방 프로필 정보 등이 함께 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->