### PR TITLE
[refactor/watchlist] 직관 기록 도메인 리팩토링

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,7 +42,7 @@ public class WatchListController {
      */
     @PostMapping
     public ApiResponse<CreateWatchListResponseDto> create(
-            @RequestBody CreateWatchListRequestDto request,
+            @Valid @RequestBody CreateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.created(watchListService.create(request, principal.getUser()));
     }
@@ -89,7 +91,7 @@ public class WatchListController {
     @PatchMapping("/{watchListId}")
     public ApiResponse<WatchListResponseDto> update(
             @PathVariable Long watchListId,
-            @RequestBody UpdateWatchListRequestDto request,
+            @Valid @RequestBody UpdateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.ok(
                 watchListService.update(

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -23,6 +23,7 @@ import com.sparta.spartatigers.domain.watchlist.dto.request.CreateWatchListReque
 import com.sparta.spartatigers.domain.watchlist.dto.request.SearchWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.request.UpdateWatchListRequestDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResponseDto;
+import com.sparta.spartatigers.domain.watchlist.dto.response.StatsResponseDto;
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.service.WatchListService;
 import com.sparta.spartatigers.global.response.ApiResponse;
@@ -134,8 +135,15 @@ public class WatchListController {
                         pageable, request, CustomUserPrincipal.getUserId(principal)));
     }
 
+    /**
+     * 회원인 유저가 등록한 직관 통계 조회
+     *
+     * @param principal 유저 정보
+     * @return {@link StatsResponseDto}
+     */
     @GetMapping("/stats")
-    public ApiResponse<?> getStats(@AuthenticationPrincipal CustomUserPrincipal principal) {
+    public ApiResponse<StatsResponseDto> getStats(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.ok(watchListService.getStats(CustomUserPrincipal.getUserId(principal)));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -54,7 +54,7 @@ public class WatchListController {
      */
     @GetMapping
     public ApiResponse<Page<WatchListResponseDto>> findAll(
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         Pageable pageable = PageRequest.of(page, size);
@@ -117,7 +117,7 @@ public class WatchListController {
      */
     @PostMapping("/search")
     public ApiResponse<?> search(
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestBody SearchWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -24,6 +24,7 @@ import com.sparta.spartatigers.domain.watchlist.dto.response.CreateWatchListResp
 import com.sparta.spartatigers.domain.watchlist.dto.response.WatchListResponseDto;
 import com.sparta.spartatigers.domain.watchlist.service.WatchListService;
 import com.sparta.spartatigers.global.response.ApiResponse;
+import com.sparta.spartatigers.global.response.MessageCode;
 
 @RestController
 @RequiredArgsConstructor
@@ -70,7 +71,7 @@ public class WatchListController {
      * @return {@link WatchListResponseDto}
      */
     @GetMapping("/{watchListId}")
-    public ApiResponse<?> findOne(
+    public ApiResponse<WatchListResponseDto> findOne(
             @PathVariable Long watchListId,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         return ApiResponse.ok(
@@ -86,7 +87,7 @@ public class WatchListController {
      * @return {@link WatchListResponseDto}
      */
     @PatchMapping("/{watchListId}")
-    public ApiResponse<?> update(
+    public ApiResponse<WatchListResponseDto> update(
             @PathVariable Long watchListId,
             @RequestBody UpdateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
@@ -103,11 +104,11 @@ public class WatchListController {
      * @return String
      */
     @DeleteMapping("/{watchListId}")
-    public ApiResponse<?> delete(
+    public ApiResponse<String> delete(
             @PathVariable Long watchListId,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         watchListService.delete(watchListId, CustomUserPrincipal.getUserId(principal));
-        return ApiResponse.ok("삭제 완료");
+        return ApiResponse.ok(MessageCode.WATCH_LIST_DELETED.getMessage());
     }
 
     /**
@@ -120,7 +121,7 @@ public class WatchListController {
      * @return {@link Page<WatchListResponseDto>}
      */
     @PostMapping("/search")
-    public ApiResponse<?> search(
+    public ApiResponse<Page<WatchListResponseDto>> search(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestBody SearchWatchListRequestDto request,

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -41,7 +41,7 @@ public class WatchListController {
     public ApiResponse<CreateWatchListResponseDto> create(
             @RequestBody CreateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ApiResponse.created(watchListService.create(request, principal));
+        return ApiResponse.created(watchListService.create(request, principal.getUser()));
     }
 
     /**
@@ -58,7 +58,8 @@ public class WatchListController {
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         Pageable pageable = PageRequest.of(page, size);
-        return ApiResponse.ok(watchListService.findAll(pageable, principal));
+        return ApiResponse.ok(
+                watchListService.findAll(pageable, CustomUserPrincipal.getUserId(principal)));
     }
 
     /**
@@ -72,7 +73,8 @@ public class WatchListController {
     public ApiResponse<?> findOne(
             @PathVariable Long watchListId,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ApiResponse.ok(watchListService.findOne(watchListId, principal));
+        return ApiResponse.ok(
+                watchListService.findOne(watchListId, CustomUserPrincipal.getUserId(principal)));
     }
 
     /**
@@ -88,7 +90,9 @@ public class WatchListController {
             @PathVariable Long watchListId,
             @RequestBody UpdateWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ApiResponse.ok(watchListService.update(watchListId, request, principal));
+        return ApiResponse.ok(
+                watchListService.update(
+                        watchListId, request, CustomUserPrincipal.getUserId(principal)));
     }
 
     /**
@@ -102,7 +106,7 @@ public class WatchListController {
     public ApiResponse<?> delete(
             @PathVariable Long watchListId,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
-        watchListService.delete(watchListId, principal);
+        watchListService.delete(watchListId, CustomUserPrincipal.getUserId(principal));
         return ApiResponse.ok("삭제 완료");
     }
 
@@ -122,11 +126,13 @@ public class WatchListController {
             @RequestBody SearchWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
         Pageable pageable = PageRequest.of(page, size);
-        return ApiResponse.ok(watchListService.search(pageable, request, principal));
+        return ApiResponse.ok(
+                watchListService.search(
+                        pageable, request, CustomUserPrincipal.getUserId(principal)));
     }
 
     @GetMapping("/stats")
     public ApiResponse<?> getStats(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ApiResponse.ok(watchListService.getStats(principal));
+        return ApiResponse.ok(watchListService.getStats(CustomUserPrincipal.getUserId(principal)));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/controller/WatchListController.java
@@ -61,7 +61,7 @@ public class WatchListController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
         return ApiResponse.ok(
                 watchListService.findAll(pageable, CustomUserPrincipal.getUserId(principal)));
     }
@@ -129,7 +129,7 @@ public class WatchListController {
             @RequestParam(defaultValue = "10") int size,
             @RequestBody SearchWatchListRequestDto request,
             @AuthenticationPrincipal CustomUserPrincipal principal) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
         return ApiResponse.ok(
                 watchListService.search(
                         pageable, request, CustomUserPrincipal.getUserId(principal)));

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/MatchDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/MatchDto.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,5 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MatchDto {
 
+    @NotNull(message = "경기 ID는 비어있을 수 없습니다.")
     private Long id;
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/RecordDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/RecordDto.java
@@ -1,5 +1,9 @@
 package com.sparta.spartatigers.domain.watchlist.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +16,11 @@ import com.sparta.spartatigers.domain.watchlist.model.entity.WatchList;
 @AllArgsConstructor
 public class RecordDto {
 
+    @NotBlank(message = "내용은 비어있을 수 없습니다.")
     private String content;
+
+    @NotNull(message = "평점은 비어있을 수 없습니다.")
+    @Min(value = 1, message = "평점은 최소 1점 이상입니다.")
     private Integer rate;
 
     public static RecordDto of(CreateWatchListRequestDto dto) {

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/CreateWatchListRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/CreateWatchListRequestDto.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +14,11 @@ import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 @AllArgsConstructor
 public class CreateWatchListRequestDto {
 
+    @NotNull(message = "경기 정보는 비어있을 수 없습니다.")
     private MatchDto match;
+
+    @NotNull(message = "기록 내용은 비어있을 수 없습니다.")
     private RecordDto record;
+
     private String seat;
 }

--- a/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/UpdateWatchListRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/watchlist/dto/request/UpdateWatchListRequestDto.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.watchlist.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +13,6 @@ import com.sparta.spartatigers.domain.watchlist.dto.RecordDto;
 @AllArgsConstructor
 public class UpdateWatchListRequestDto {
 
+    @NotNull(message = "기록 내용은 비어있을 수 없습니다.")
     private RecordDto record;
 }

--- a/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/response/MessageCode.java
@@ -23,9 +23,10 @@ public enum MessageCode {
     UPDATE_EXCHANGE_REQUEST_SUCCESS("교환 요청 상태 변경을 성공했습니다."),
     COMPLETE_EXCHANGE_SUCCESS("교환을 성공적으로 완료했습니다."),
 
-// 아이템
+    // 아이템
 
-// 직관 기록
+    // 직관 기록
+    WATCH_LIST_DELETED("직관 기록이 삭제되었습니다.")
 
 // 공통
 ;


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- Request parm의 page default를 1로 수정
- 요청 시 입력 값 검증 `@Valid` 추가
- `CustomUserPrincipal` 전체를 넘기지 않고, 객체에서 필요한 값만 빼서 전달
- 제네릭 반환 타입 와일드 카드로 되어있는 부분 수정

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- #127 

## 💬 기타 코멘트
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 관전 기록 통계 정보를 조회할 수 있는 통계 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 모든 입력값에 대해 유효성 검사가 강화되어, 필수 항목 누락 시 명확한 안내 메시지가 제공됩니다.

* **개선 사항**
  * 페이지네이션 기본값이 1페이지부터 시작하도록 변경되었습니다.
  * API 응답 타입이 더 명확하게 개선되어 일관된 데이터 형식을 제공합니다.
  * 삭제 시 표준화된 메시지가 반환됩니다.
  * 사용자 인증 및 식별 방식이 일관성 있게 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->