### PR TITLE
[라이브 보드] 경기 중계 전송 기능

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/listener/StompSessionEventListener.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/listener/StompSessionEventListener.java
@@ -6,9 +6,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.sparta.spartatigers.domain.chatroom.registry.RedisUserSessionRegistry;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class StompSessionEventListener {

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
@@ -50,7 +50,6 @@ public class LiveBoardRoomController {
         return liveBoardRoomService.findRoomsByDate(date);
     }
 
-    @GetMapping("/{roomId}")
     @DeleteMapping("/{roomId}")
     public ApiResponse<String> deleteRoom(@PathVariable String roomId) {
         return ApiResponse.ok(liveBoardRoomService.deleteRoom(roomId));

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
@@ -1,12 +1,15 @@
 package com.sparta.spartatigers.domain.liveboard.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -37,6 +40,17 @@ public class LiveBoardRoomController {
         return liveBoardRoomService.findTodayRooms();
     }
 
+    @GetMapping()
+    public List<LiveBoardRoomResponseDto> getRoomsByDate(
+            @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date) {
+        if (date == null) {
+            date = LocalDate.now();
+        }
+
+        return liveBoardRoomService.findRoomsByDate(date);
+    }
+
+    @GetMapping("/{roomId}")
     @DeleteMapping("/{roomId}")
     public ApiResponse<String> deleteRoom(@PathVariable String roomId) {
         return ApiResponse.ok(liveBoardRoomService.deleteRoom(roomId));

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/response/LiveBoardRoomResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/response/LiveBoardRoomResponseDto.java
@@ -3,21 +3,38 @@ package com.sparta.spartatigers.domain.liveboard.dto.response;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import com.sparta.spartatigers.domain.liveboard.model.LiveBoardRoom;
+import com.sparta.spartatigers.domain.match.model.entity.Match;
+import com.sparta.spartatigers.domain.team.model.entity.Team;
 
+@Builder
 @Getter
 @AllArgsConstructor
 public class LiveBoardRoomResponseDto {
 
     private String roomId;
     private String title;
+    private Long matchId;
+    private String awayTeamName;
+    private Team.Code awayTeamCode;
+    private String homeTeamName;
+    private Team.Code homeTeamCode;
     private LocalDateTime startedAt;
+    private Match.MatchResult matchResult;
+    private String position;
     private Long connectCount;
 
     public static LiveBoardRoomResponseDto of(LiveBoardRoom room, long connectCount) {
-        return new LiveBoardRoomResponseDto(
-                room.getRoomId(), room.getTitle(), room.getOpenAt(), connectCount);
+        return builder()
+                .roomId(room.getRoomId())
+                .title(room.getTitle())
+                .startedAt(room.getOpenAt())
+                .connectCount(connectCount)
+                .build();
+        // return new LiveBoardRoomResponseDto(
+        //         room.getRoomId(), room.getTitle(), room.getOpenAt(), connectCount);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/model/GameMessage.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/model/GameMessage.java
@@ -1,0 +1,18 @@
+package com.sparta.spartatigers.domain.liveboard.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameMessage {
+    private Long matchId;
+    private List<GamePlayer> players;
+    private MatchScore matchScore;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/model/GamePlayer.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/model/GamePlayer.java
@@ -1,0 +1,15 @@
+package com.sparta.spartatigers.domain.liveboard.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GamePlayer {
+    private String name;
+    private String role;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/model/MatchScore.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/model/MatchScore.java
@@ -1,0 +1,16 @@
+package com.sparta.spartatigers.domain.liveboard.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchScore {
+    private Long strike = 0L;
+    private Long ball = 0L;
+    private Long out = 0L;
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/pubsub/LiveBoardMatchSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/pubsub/LiveBoardMatchSubscriber.java
@@ -1,0 +1,40 @@
+package com.sparta.spartatigers.domain.liveboard.pubsub;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.sparta.spartatigers.domain.liveboard.model.GameMessage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LiveBoardMatchSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            GameMessage gameMessage =
+                    objectMapper.readValue(
+                            new String(message.getBody(), StandardCharsets.UTF_8),
+                            GameMessage.class);
+
+            messagingTemplate.convertAndSend(
+                    "/server/liveboard/room/" + gameMessage.getMatchId() + "/game", gameMessage);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/pubsub/LiveBoardMatchSubscriberConfig.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/pubsub/LiveBoardMatchSubscriberConfig.java
@@ -1,0 +1,25 @@
+package com.sparta.spartatigers.domain.liveboard.pubsub;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class LiveBoardMatchSubscriberConfig {
+    private final LiveBoardMatchSubscriber liveBoardMatchSubscriber;
+    private final RedisConnectionFactory connectionFactory;
+
+    @Bean
+    public RedisMessageListenerContainer redisLiveBoardMatchMessageListenerContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(
+                liveBoardMatchSubscriber, new PatternTopic("live_board:game:*"));
+        return container;
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/repository/LiveBoardRoomRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/repository/LiveBoardRoomRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.spartatigers.domain.liveboard.repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.annotation.PostConstruct;
@@ -20,11 +21,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Slf4j
 public class LiveBoardRoomRepository {
 
+    private static final String LIVEBOARD_ROOMS = "liveboard:rooms";
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
     private HashOperations<String, String, LiveBoardRoom> opsHash;
-
-    private static final String LIVEBOARD_ROOMS = "liveboard:rooms";
 
     @PostConstruct
     private void init() {
@@ -42,7 +42,12 @@ public class LiveBoardRoomRepository {
     }
 
     public List<LiveBoardRoom> findAllRoom() {
-        return opsHash.values(LIVEBOARD_ROOMS);
+        List<LiveBoardRoom> rooms = new ArrayList<>();
+        for (Object room : opsHash.values(LIVEBOARD_ROOMS)) {
+            rooms.add(objectMapper.convertValue(room, LiveBoardRoom.class));
+        }
+
+        return rooms;
     }
 
     public void deleteRoom(String roomId) {

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRedisService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRedisService.java
@@ -27,8 +27,6 @@ import com.sparta.spartatigers.domain.liveboard.pubsub.RedisMessageSubscriber;
 import com.sparta.spartatigers.domain.liveboard.repository.LiveBoardConnectionRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
-import com.sparta.spartatigers.global.exception.ExceptionCode;
-import com.sparta.spartatigers.global.exception.WebSocketException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -83,31 +81,31 @@ public class LiveBoardRedisService {
 
     // 채팅 전송
     public void handleMessage(LiveBoardMessage message, Principal principal) {
-        Long senderId = null;
-        String nickname = "비회원";
-
-        if (principal instanceof CustomUserPrincipal customUserPrincipal) {
-            senderId = customUserPrincipal.getUser().getId();
-            nickname = customUserPrincipal.getUser().getNickname();
-        } else if (principal != null) {
-            try {
-                senderId = Long.valueOf(principal.getName());
-                nickname = userRepository.findNicknameById(senderId).orElse("비회원");
-            } catch (NumberFormatException e) {
-                throw new WebSocketException(ExceptionCode.WEBSOCKET_UNAUTHORIZED);
-            }
-        }
-
-        if (senderId == null) {
-            throw new WebSocketException(ExceptionCode.WEBSOCKET_UNAUTHORIZED);
-        }
-        message =
-                LiveBoardMessage.of(
-                        message.getRoomId(),
-                        senderId,
-                        nickname,
-                        message.getContent(),
-                        MessageType.CHAT);
+        // Long senderId = null;
+        // String nickname = "비회원";
+        //
+        // if (principal instanceof CustomUserPrincipal customUserPrincipal) {
+        //     senderId = customUserPrincipal.getUser().getId();
+        //     nickname = customUserPrincipal.getUser().getNickname();
+        // } else if (principal != null) {
+        //     try {
+        //         senderId = Long.valueOf(principal.getName());
+        //         nickname = userRepository.findNicknameById(senderId).orElse("비회원");
+        //     } catch (NumberFormatException e) {
+        //         throw new WebSocketException(ExceptionCode.WEBSOCKET_UNAUTHORIZED);
+        //     }
+        // }
+        //
+        // if (senderId == null) {
+        //     throw new WebSocketException(ExceptionCode.WEBSOCKET_UNAUTHORIZED);
+        // }
+        // message =
+        //         LiveBoardMessage.of(
+        //                 message.getRoomId(),
+        //                 message.getSenderId(),
+        //                 message.getSenderNickName(),
+        //                 message.getContent(),
+        //                 MessageType.CHAT);
 
         // Redis publish
         ChannelTopic topic = getOrInitTopic(message.getRoomId());

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRoomService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRoomService.java
@@ -32,8 +32,8 @@ public class LiveBoardRoomService {
     // 라이브 보드룸 생성
     public String createTodayRoom() {
 
-        // 오늘 경기 일정 찾기
-        LocalDateTime start = LocalDate.now().atStartOfDay();
+        // 오늘 경기 일정 찾기 TODO 테스트 용으로 하루 빼놨는데 지워야 함
+        LocalDateTime start = LocalDate.now().minusDays(1).atStartOfDay();
         LocalDateTime end = start.plusDays(1);
         List<Match> matches = matchRepository.findAllByMatchTimeBetween(start, end);
 

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRoomService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRoomService.java
@@ -2,6 +2,7 @@ package com.sparta.spartatigers.domain.liveboard.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,6 +10,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.sparta.spartatigers.domain.liveboard.dto.response.LiveBoardRoomResponseDto;
 import com.sparta.spartatigers.domain.liveboard.model.LiveBoardRoom;
@@ -17,6 +19,7 @@ import com.sparta.spartatigers.domain.liveboard.repository.LiveBoardRoomReposito
 import com.sparta.spartatigers.domain.match.model.entity.Match;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LiveBoardRoomService {
@@ -70,18 +73,108 @@ public class LiveBoardRoomService {
     public List<LiveBoardRoomResponseDto> findTodayRooms() {
         LocalDateTime start = LocalDate.now().atStartOfDay();
         LocalDateTime end = start.plusDays(1);
+        List<Match> matches = matchRepository.findAllByMatchTimeBetween(start, end);
+        List<LiveBoardRoomResponseDto> rooms =
+                roomRepository.findAllRoom().stream()
+                        .filter(
+                                room ->
+                                        !room.getOpenAt().isBefore(start)
+                                                && room.getOpenAt().isBefore(end))
+                        .map(
+                                room -> {
+                                    Long count =
+                                            connectionRepository.getConnectionCount(
+                                                    room.getRoomId());
+                                    return LiveBoardRoomResponseDto.of(room, count);
+                                })
+                        .toList();
 
-        return roomRepository.findAllRoom().stream()
-                .filter(room -> !room.getOpenAt().isBefore(start) && room.getOpenAt().isBefore(end))
-                .map(
-                        room -> {
-                            Long count = connectionRepository.getConnectionCount(room.getRoomId());
-                            return LiveBoardRoomResponseDto.of(room, count);
-                        })
-                .toList();
+        return rooms;
     }
 
-    // 라이브 보드룸 삭제
+    // 경기 방이 안생기면 데이터를 제대로 못가지고 옴
+    public List<LiveBoardRoomResponseDto> findRoomsByDate(LocalDate start) {
+        LocalDateTime end = start.plusDays(1).atStartOfDay();
+        List<Match> matches = matchRepository.findAllByMatchTimeBetween(start.atStartOfDay(), end);
+        List<LiveBoardRoomResponseDto> rooms =
+                roomRepository.findAllRoom().stream()
+                        .filter(
+                                room ->
+                                        !room.getOpenAt().isBefore(start.atStartOfDay())
+                                                && room.getOpenAt().isBefore(end))
+                        .map(
+                                room -> {
+                                    Long count =
+                                            connectionRepository.getConnectionCount(
+                                                    room.getRoomId());
+                                    return LiveBoardRoomResponseDto.of(room, count);
+                                })
+                        .toList();
+
+        List<LiveBoardRoomResponseDto> liveBoardRoomResponseDtos = new ArrayList<>();
+        // 리스트로 제목이 같으면 합친다
+        // match.getAwayTeam().getName() + "VS" + match.getHomeTeam().getName()
+        // TODO 이거도 매치별로 룸을 넣어주기, 룸이 없을 수도 있겠다.
+        for (int i = 0; i < matches.size(); i++) {
+            LiveBoardRoomResponseDto dto = null;
+
+            boolean findRooms = false;
+            for (int j = 0; j < rooms.size(); j++) {
+                if (rooms.get(j)
+                        .getTitle()
+                        .equals(
+                                matches.get(i).getAwayTeam().getName()
+                                        + "VS"
+                                        + matches.get(i).getHomeTeam().getName())) {
+                    findRooms = true;
+
+                    dto =
+                            LiveBoardRoomResponseDto.builder()
+                                    .matchId(matches.get(i).getId())
+                                    .title(
+                                            matches.get(i).getAwayTeam().getName()
+                                                    + "VS"
+                                                    + matches.get(i).getHomeTeam().getName())
+                                    .roomId(rooms.get(j).getRoomId())
+                                    .connectCount(rooms.get(j).getConnectCount())
+                                    .startedAt(matches.get(i).getMatchTime())
+                                    .awayTeamCode(matches.get(i).getAwayTeam().getCode())
+                                    .homeTeamCode(matches.get(i).getHomeTeam().getCode())
+                                    .awayTeamName(matches.get(i).getAwayTeam().getName())
+                                    .homeTeamName(matches.get(i).getHomeTeam().getName())
+                                    .matchResult(matches.get(i).getMatchResult())
+                                    .position(matches.get(i).getStadium().getName())
+                                    .build();
+
+                    break;
+                }
+            }
+
+            if (findRooms == false) {
+                dto =
+                        LiveBoardRoomResponseDto.builder()
+                                .matchId(matches.get(i).getId())
+                                .title(
+                                        matches.get(i).getAwayTeam().getName()
+                                                + "VS"
+                                                + matches.get(i).getHomeTeam().getName())
+                                .connectCount(0L)
+                                .startedAt(matches.get(i).getMatchTime())
+                                .awayTeamCode(matches.get(i).getAwayTeam().getCode())
+                                .homeTeamCode(matches.get(i).getHomeTeam().getCode())
+                                .awayTeamName(matches.get(i).getAwayTeam().getName())
+                                .homeTeamName(matches.get(i).getHomeTeam().getName())
+                                .matchResult(matches.get(i).getMatchResult())
+                                .position(matches.get(i).getStadium().getName())
+                                .build();
+            }
+
+            liveBoardRoomResponseDtos.add(dto);
+        }
+
+        return liveBoardRoomResponseDtos;
+    }
+
     public String deleteRoom(String roomId) {
         LiveBoardRoom room = roomRepository.findRoomById(roomId);
 

--- a/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
@@ -2,52 +2,51 @@ package com.sparta.spartatigers.global.handler;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.global.util.JwtUtil;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
 @Component
 @Log4j2
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
-    private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
+	private final JwtUtil jwtUtil;
+	private final UserRepository userRepository;
 
-    @Override
-    public void onAuthenticationSuccess(
-            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-            throws IOException, ServletException {
-        CustomUserPrincipal customUser = (CustomUserPrincipal) authentication.getPrincipal();
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+		throws IOException, ServletException {
+		CustomUserPrincipal customUser = (CustomUserPrincipal)authentication.getPrincipal();
 
-        String provider = customUser.getProvider();
-        String providerId = customUser.getUser().getProviderId();
-        String email = customUser.getUser().getEmail();
-        String nickname = customUser.getUser().getNickname();
-        String path = customUser.getUser().getPath();
+		String provider = customUser.getProvider();
+		String providerId = customUser.getUser().getProviderId();
+		String email = customUser.getUser().getEmail();
+		String nickname = customUser.getUser().getNickname();
+		String path = customUser.getUser().getPath();
 
-        log.info("email: {}", email);
-        log.info("nickname: {}", nickname);
-        log.info("path: {}", path);
+		log.info("email: {}", email);
+		log.info("nickname: {}", nickname);
+		log.info("path: {}", path);
 
-        String token = jwtUtil.generateToken(email, "USER");
+		String token = jwtUtil.generateToken(email, "USER");
 
-        if (!userRepository.existsByProviderId(providerId)) {
-            User newUser = User.from(provider, providerId, email, nickname, path);
-            userRepository.save(newUser);
-        }
+		if (!userRepository.existsByProviderId(providerId)) {
+			User newUser = User.from(provider, providerId, email, nickname, path);
+			userRepository.save(newUser);
+		}
 
-        response.sendRedirect("http://localhost:5173/oauth2/redirect?token=" + token);
-    }
+		response.sendRedirect("https://fe.yaguniv.site/redirect?token=" + token);
+	}
 }

--- a/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
@@ -48,8 +48,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             userRepository.save(newUser);
         }
 
-        response.sendRedirect(
-                "http://sparta-tigers-fe.s3-website.ap-northeast-2.amazonaws.com/oauth2/redirect?token="
-                        + token);
+        response.sendRedirect("http://localhost:5173/oauth2/redirect?token=" + token);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
@@ -2,51 +2,52 @@ package com.sparta.spartatigers.global.handler;
 
 import java.io.IOException;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.global.util.JwtUtil;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-
 @Component
 @Log4j2
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
-	private final JwtUtil jwtUtil;
-	private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
 
-	@Override
-	public void onAuthenticationSuccess(
-		HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-		throws IOException, ServletException {
-		CustomUserPrincipal customUser = (CustomUserPrincipal)authentication.getPrincipal();
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        CustomUserPrincipal customUser = (CustomUserPrincipal) authentication.getPrincipal();
 
-		String provider = customUser.getProvider();
-		String providerId = customUser.getUser().getProviderId();
-		String email = customUser.getUser().getEmail();
-		String nickname = customUser.getUser().getNickname();
-		String path = customUser.getUser().getPath();
+        String provider = customUser.getProvider();
+        String providerId = customUser.getUser().getProviderId();
+        String email = customUser.getUser().getEmail();
+        String nickname = customUser.getUser().getNickname();
+        String path = customUser.getUser().getPath();
 
-		log.info("email: {}", email);
-		log.info("nickname: {}", nickname);
-		log.info("path: {}", path);
+        log.info("email: {}", email);
+        log.info("nickname: {}", nickname);
+        log.info("path: {}", path);
 
-		String token = jwtUtil.generateToken(email, "USER");
+        String token = jwtUtil.generateToken(email, "USER");
 
-		if (!userRepository.existsByProviderId(providerId)) {
-			User newUser = User.from(provider, providerId, email, nickname, path);
-			userRepository.save(newUser);
-		}
+        if (!userRepository.existsByProviderId(providerId)) {
+            User newUser = User.from(provider, providerId, email, nickname, path);
+            userRepository.save(newUser);
+        }
 
-		response.sendRedirect("https://fe.yaguniv.site/redirect?token=" + token);
-	}
+        response.sendRedirect("https://fe.yaguniv.site/redirect?token=" + token);
+    }
 }


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
-  라이브 보드 게임 중계 전송 기능 추가

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- 

## 💬 기타 코멘트
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 날짜별 라이브보드 방 목록 조회 API가 추가되었습니다.
  * 라이브보드 방 응답에 경기 정보(경기 ID, 팀명, 팀 코드, 경기 결과 등) 필드가 확장되었습니다.
  * 실시간 경기 메시지 처리 및 Redis Pub/Sub 기반 WebSocket 전송 기능이 추가되었습니다.
  * 경기 메시지, 선수, 점수 관련 데이터 모델이 도입되었습니다.

* **버그 수정**
  * 라이브보드 방 목록 조회 시 날짜별, 오늘 날짜별 필터링 및 매칭 로직이 개선되었습니다.

* **기타**
  * OAuth2 로그인 성공 시 리다이렉트 주소가 운영 환경 주소로 변경되었습니다.
  * 내부 로깅 기능이 강화되고 코드 구조 일부가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->