### PR TITLE
hotfix/jungmini

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/chatroom/service/ChatMessageService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/chatroom/service/ChatMessageService.java
@@ -38,9 +38,9 @@ public class ChatMessageService {
     @Transactional
     public void sendMessage(Long senderId, ChatMessageRequest request) {
         String rateLimitKey = "rate-limit:user:" + senderId;
-        if (redisRateLimiter.isRateLimited(rateLimitKey, MESSAGE_LIMIT, LIMIT_DURATION)) {
-            throw new InvalidRequestException(ExceptionCode.TOO_MANY_MESSAGE);
-        }
+        // if (redisRateLimiter.isRateLimited(rateLimitKey, MESSAGE_LIMIT, LIMIT_DURATION)) {
+        //     throw new InvalidRequestException(ExceptionCode.TOO_MANY_MESSAGE);
+        // }
 
         Long roomId = request.getRoomId();
         String messageText = request.getMessage();

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -76,7 +76,6 @@ public class ItemService {
 
         Long userId = principal.getUser().getId();
         log.debug("[findAllItems] 사용자 ID: {}", userId);
-
         List<Long> nearByUserIds = locationService.findUsersNearBy(userId, SEARCH_RADIUS_KM);
         log.debug("[findAllItems] 근처 사용자 수: {}", nearByUserIds.size());
         nearByUserIds.add(userId);

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRedisService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveBoardRedisService.java
@@ -25,8 +25,6 @@ import com.sparta.spartatigers.domain.liveboard.pubsub.RedisMessageSubscriber;
 import com.sparta.spartatigers.domain.liveboard.repository.LiveBoardConnectionRepository;
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
-import com.sparta.spartatigers.global.exception.ExceptionCode;
-import com.sparta.spartatigers.global.exception.WebSocketException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -74,25 +72,6 @@ public class LiveBoardRedisService {
 
     // 채팅 전송
     public void handleMessage(LiveBoardMessage message, Principal principal) {
-        Long senderId = null;
-        String nickname = "비회원";
-
-        if (principal == null) {
-            throw new WebSocketException(ExceptionCode.WEBSOCKET_UNAUTHORIZED);
-        } else {
-            senderId = findSenderId(principal);
-            nickname = userRepository.findNicknameById(senderId).orElse("비회원");
-        }
-
-        message =
-                LiveBoardMessage.of(
-                        message.getRoomId(),
-                        senderId,
-                        nickname,
-                        message.getContent(),
-                        MessageType.CHAT);
-
-        // Redis publish
         ChannelTopic topic = getOrInitTopic(message.getRoomId());
         redisPublisher.publish(topic, message);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/controller/UserController.java
@@ -3,7 +3,14 @@ package com.sparta.spartatigers.domain.user.controller;
 import jakarta.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
@@ -39,6 +46,10 @@ public class UserController {
     @GetMapping("/me")
     public ApiResponse<UserInfoResponseDto> getUserInfo(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        if (userPrincipal == null) {
+            return ApiResponse.ok(null);
+        }
+
         Long userId = userPrincipal.getUser().getId();
         UserInfoResponseDto userInfoResponseDto = userService.getUserInfo(userId);
         return ApiResponse.ok(userInfoResponseDto);

--- a/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
@@ -2,51 +2,52 @@ package com.sparta.spartatigers.global.handler;
 
 import java.io.IOException;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.global.util.JwtUtil;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-
 @Component
 @Log4j2
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
-	private final JwtUtil jwtUtil;
-	private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
 
-	@Override
-	public void onAuthenticationSuccess(
-		HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-		throws IOException, ServletException {
-		CustomUserPrincipal customUser = (CustomUserPrincipal)authentication.getPrincipal();
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        CustomUserPrincipal customUser = (CustomUserPrincipal) authentication.getPrincipal();
 
-		String provider = customUser.getProvider();
-		String providerId = customUser.getUser().getProviderId();
-		String email = customUser.getUser().getEmail();
-		String nickname = customUser.getUser().getNickname();
-		String path = customUser.getUser().getPath();
+        String provider = customUser.getProvider();
+        String providerId = customUser.getUser().getProviderId();
+        String email = customUser.getUser().getEmail();
+        String nickname = customUser.getUser().getNickname();
+        String path = customUser.getUser().getPath();
 
-		log.info("email: {}", email);
-		log.info("nickname: {}", nickname);
-		log.info("path: {}", path);
+        log.info("email: {}", email);
+        log.info("nickname: {}", nickname);
+        log.info("path: {}", path);
 
-		String token = jwtUtil.generateToken(email, "USER");
+        String token = jwtUtil.generateToken(email, "USER");
 
-		if (!userRepository.existsByProviderId(providerId)) {
-			User newUser = User.from(provider, providerId, email, nickname, path);
-			userRepository.save(newUser);
-		}
+        if (!userRepository.existsByProviderId(providerId)) {
+            User newUser = User.from(provider, providerId, email, nickname, path);
+            userRepository.save(newUser);
+        }
 
-		response.sendRedirect("https://yaguniv.site/redirect?token=" + token);
-	}
+        response.sendRedirect("https://yaguniv.site/redirect?token=" + token);
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sparta/spartatigers/global/handler/OAuth2SuccessHandler.java
@@ -2,52 +2,51 @@ package com.sparta.spartatigers.global.handler;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
 import com.sparta.spartatigers.domain.user.model.CustomUserPrincipal;
 import com.sparta.spartatigers.domain.user.model.entity.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.global.util.JwtUtil;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
 @Component
 @Log4j2
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
-    private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
+	private final JwtUtil jwtUtil;
+	private final UserRepository userRepository;
 
-    @Override
-    public void onAuthenticationSuccess(
-            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-            throws IOException, ServletException {
-        CustomUserPrincipal customUser = (CustomUserPrincipal) authentication.getPrincipal();
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+		throws IOException, ServletException {
+		CustomUserPrincipal customUser = (CustomUserPrincipal)authentication.getPrincipal();
 
-        String provider = customUser.getProvider();
-        String providerId = customUser.getUser().getProviderId();
-        String email = customUser.getUser().getEmail();
-        String nickname = customUser.getUser().getNickname();
-        String path = customUser.getUser().getPath();
+		String provider = customUser.getProvider();
+		String providerId = customUser.getUser().getProviderId();
+		String email = customUser.getUser().getEmail();
+		String nickname = customUser.getUser().getNickname();
+		String path = customUser.getUser().getPath();
 
-        log.info("email: {}", email);
-        log.info("nickname: {}", nickname);
-        log.info("path: {}", path);
+		log.info("email: {}", email);
+		log.info("nickname: {}", nickname);
+		log.info("path: {}", path);
 
-        String token = jwtUtil.generateToken(email, "USER");
+		String token = jwtUtil.generateToken(email, "USER");
 
-        if (!userRepository.existsByProviderId(providerId)) {
-            User newUser = User.from(provider, providerId, email, nickname, path);
-            userRepository.save(newUser);
-        }
+		if (!userRepository.existsByProviderId(providerId)) {
+			User newUser = User.from(provider, providerId, email, nickname, path);
+			userRepository.save(newUser);
+		}
 
-        response.sendRedirect("https://fe.yaguniv.site/redirect?token=" + token);
-    }
+		response.sendRedirect("https://yaguniv.site/redirect?token=" + token);
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,9 @@ spring:
       - redis.yml
       - application-social.yml
       - application-s3.yml
-  # ?? ??? ?? ????
-  web.resources.add-mappings: false
+  web:
+    resources:
+      add-mappings: false
 
 server:
   tomcat:
@@ -22,3 +23,10 @@ server:
 logging:
   level:
     com.sparta.sparta-tigers.global.config.StompAuthInterceptor: info # 개발할 때 info 운영 단계에서는 warn으로
+    org.springframework.security: debug
+    org.springframework.security.web: debug
+    org.springframework.security.authentication: debug
+    org.springframework.security.authorization: debug
+    org.springframework.security.config: debug
+    org.springframework.security.core: debug
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,10 +23,4 @@ server:
 logging:
   level:
     com.sparta.sparta-tigers.global.config.StompAuthInterceptor: info # 개발할 때 info 운영 단계에서는 warn으로
-    org.springframework.security: debug
-    org.springframework.security.web: debug
-    org.springframework.security.authentication: debug
-    org.springframework.security.authorization: debug
-    org.springframework.security.config: debug
-    org.springframework.security.core: debug
 


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 리팩토링 / 수정
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 소셜로그인, 일반 로그인 관련 로직 수정 (서버 변경 X, 클라이언트에서 window.location대신 a태그로 이동 예정) TODO: 배포환경 테스트 필요
- 교환 지도 관련: 일반 로그인, 소셜 로그인간 주변 인증 관련 null에러 때문에 위치 못가져오던 에러 수정
- 라이브 보드: 로그인 안한 유저, 로그인 한 유저 전부 웹소켓 커넥션 맺을 수 있도록 수정, 로그인한 사람만 메세지 보낼 수 있도록 수정, 비회원은 채팅 조회만 가능하게 수정
- TODO 교환 채팅 관련해서 스크롤 쭉 안내려가는 로직 있는데 겉에 회색 스크롤 때문에 안되는데 어캐 내리는지 모르겠음 일단 PR 올릴 예정

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- 

## 💬 기타 코멘트
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 사용자 정보 조회 시 인증 정보가 없을 경우 빈 응답을 반환하도록 개선되었습니다.
  * OAuth2 로그인 성공 후 리디렉션 URL이 수정되었습니다.

* **리팩터**
  * WebSocket 연결 시 사용자 정보 추출 방식이 간소화되었습니다.
  * LiveBoard 메시지 처리 시 발신자 검증 및 정보 보강 로직이 제거되었습니다.
  * 메시지 전송 시 레이트 리미팅(전송 제한) 기능이 비활성화되었습니다.

* **스타일**
  * 일부 코드의 공백 및 들여쓰기가 정리되었습니다.
  * YAML 설정 파일의 구조가 가독성 있게 재정렬되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->